### PR TITLE
chore(packages): :hammer: support @libsql/darwin-x64

### DIFF
--- a/packages/swarm-mail/package.json
+++ b/packages/swarm-mail/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "@libsql/client": "^0.15.15",
-    "@libsql/darwin-arm64": "^0.5.22",
     "debug": "^4.4.3",
     "drizzle-orm": "^0.41.0",
     "effect": "^3.19.12",
@@ -59,6 +58,7 @@
     "vitest": "^2.1.8"
   },
   "optionalDependencies": {
+    "@libsql/darwin-arm64": "^0.5.22",
     "@libsql/darwin-x64": "^0.5.22"
   }
 }


### PR DESCRIPTION
This pull request introduces a new optional dependency to the `packages/swarm-mail/package.json` file. The addition is minor and ensures that the `@libsql/darwin-x64` package is available as an optional dependency for the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved macOS platform-specific packages to optional installation, adding support for both arm64 and x64 variants and removing a hard requirement on one macOS package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->