### PR TITLE
fix: move evalite and vitest to production dependencies

### DIFF
--- a/packages/opencode-swarm-plugin/package.json
+++ b/packages/opencode-swarm-plugin/package.json
@@ -42,12 +42,14 @@
     "@clack/prompts": "^0.11.0",
     "@opencode-ai/plugin": "^1.0.134",
     "effect": "^3.19.12",
+    "evalite": "^1.0.0-beta.10",
     "gray-matter": "^4.0.3",
     "ioredis": "^5.4.1",
     "minimatch": "^10.1.1",
     "pino": "^9.6.0",
     "pino-roll": "^1.3.0",
     "swarm-mail": "workspace:*",
+    "vitest": "^4.0.15",
     "yaml": "^2.8.2",
     "zod": "4.1.8"
   },
@@ -56,11 +58,9 @@
     "@types/minimatch": "^6.0.0",
     "ai": "6.0.0-beta.150",
     "bun-types": "^1.3.4",
-    "evalite": "^1.0.0-beta.10",
     "pino-pretty": "^13.1.3",
     "turbo": "^2.6.3",
-    "typescript": "^5.7.0",
-    "vitest": "^4.0.15"
+    "typescript": "^5.7.0"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": "^1.0.0"


### PR DESCRIPTION
## Summary
- **Move `evalite` from devDependencies to dependencies**: Required at runtime by `eval-runner.ts` for imports like `runEvalite`, `createInMemoryStorage`, and `Evalite` types
- **Move `vitest` from devDependencies to dependencies**: Required by evalite for execution (vitest/node module)

## Problem
When installing `opencode-swarm-plugin` globally, users encounter module resolution errors:
- `Cannot find module 'evalite/runner'`
- `Cannot find module 'vitest/node'`

## Root Cause
These packages were incorrectly categorized as devDependencies, but they are runtime dependencies needed for the plugin to function properly after installation.

## Impact
- Fixes global installation issues
- Ensures all required modules are available when plugin is used
- No breaking changes - only affects dependency resolution

## Testing
- Verified that after manually installing these packages globally, the plugin works correctly
- The build script already excludes these packages with `--external` flags, so they won't be bundled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to promote vitest and evalite from development to runtime dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->