### PR TITLE
fix(dashboard): correct cell status property to fix startup crash

### DIFF
--- a/packages/swarm-dashboard/src/components/CellsPane.tsx
+++ b/packages/swarm-dashboard/src/components/CellsPane.tsx
@@ -79,7 +79,7 @@ export const CellsPane = ({ events, onCellSelect }: CellsPaneProps) => {
     for (const event of cellStatusChanged) {
       const cell = cellMap.get(event.cell_id);
       if (cell) {
-        cell.status = event.new_status as Cell['status'];
+        cell.status = event.to_status as Cell['status'];
       }
     }
 


### PR DESCRIPTION
This PR fixes a TypeScript error in the swarm-dashboard where `new_status` was used instead of `to_status`. This resolves the OpenCode crash at startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cell status update mechanism to correctly propagate status changes within the dashboard.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->