### PR TITLE
Add clarification note about installing bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 
 ---
 
+_Note: You will need Bun installed to run this plugin. You can follow the instructions [here](https://bun.com/docs/installation)._
+
 ## 30-Second Start
 
 ```bash


### PR DESCRIPTION
Just got things installed and went to run `swarm setup` and got hit with an error saying that I didn't have bun installed. So I had to track down the bun installation docs (a quick and easy find). I figured since the adoption of bun is still on the low-end, it might save a user a search by just linking to Bun's official installation docs and note to the user that they will need it.

My feelings won't be hurt at all if you don't want this note either, I'm guessing few people don't have bun installed already given the lack of mention now, so maybe this is unnecessary. If you don't feel like this note is worth having, feel free to close. I just wanted to throw it out there in case it was worth having.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a requirement note in README.md clarifying that Bun is needed to run the plugin, including a link to installation instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->