### PR TITLE
feat(opencode-swarm-plugin): add compact result rendering for semantic-memory and CASS tools

### DIFF
--- a/.changeset/compact-result-rendering.md
+++ b/.changeset/compact-result-rendering.md
@@ -1,0 +1,10 @@
+---
+"opencode-swarm-plugin": minor
+---
+
+Add compact list rendering for semantic-memory_find and cass_search tools
+
+- New result-formatter utility with formatMemoryResults and formatCassResults
+- semantic-memory_find now shows compact results with score, decay %, and age
+- cass_search now shows compact results with agent, path:line, and preview
+- Improved readability for AI agent outputs

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "opencode-swarm-monorepo",

--- a/packages/opencode-swarm-plugin/src/cass-tools.test.ts
+++ b/packages/opencode-swarm-plugin/src/cass-tools.test.ts
@@ -40,10 +40,25 @@ describe("cass_search", () => {
 		// Should not throw
 		expect(result).toBeTruthy();
 		
-		// Should either return results or "No results found" message
-		if (result.includes("No results found")) {
-			expect(result).toContain("Try:");
+		// Should start with the 🔍 CASS Search header
+		expect(result).toContain("🔍 CASS Search");
+		
+		// Should either have results or show no results message
+		if (result.includes("0 results")) {
+			expect(result).toContain("No matching sessions found");
+			expect(result).toContain("broader search terms");
 		}
+	});
+
+	test("returns compact format with header", async () => {
+		const result = await cassTools.cass_search.execute({ query: "authentication" });
+		
+		// Always starts with CASS Search header emoji
+		expect(result.startsWith("🔍 CASS Search")).toBe(true);
+		
+		// If there are results, they should follow the [agent] path:line - "preview" format
+		const lines = result.split("\n");
+		expect(lines.length).toBeGreaterThanOrEqual(1); // At least header line
 	});
 });
 

--- a/packages/opencode-swarm-plugin/src/result-formatter.test.ts
+++ b/packages/opencode-swarm-plugin/src/result-formatter.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Result Formatter Tests
+ *
+ * Tests for shared result formatting utilities used by semantic-memory and CASS tools.
+ * Following TDD - tests written first, implementation follows.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+	truncate,
+	formatAge,
+	formatDecay,
+	formatScore,
+	formatMemoryResults,
+	formatCassResults,
+	type MemoryResult,
+	type CassResult,
+} from "./result-formatter";
+
+// ============================================================================
+// Helper Function Tests
+// ============================================================================
+
+describe("truncate", () => {
+	test("returns original string if shorter than maxLen", () => {
+		expect(truncate("short", 10)).toBe("short");
+	});
+
+	test("truncates string and adds ellipsis", () => {
+		expect(truncate("this is a very long string", 10)).toBe("this is a...");
+	});
+
+	test("handles empty string", () => {
+		expect(truncate("", 10)).toBe("");
+	});
+
+	test("handles string exactly at maxLen", () => {
+		expect(truncate("exactly10!", 10)).toBe("exactly10!");
+	});
+
+	test("handles maxLen of 0", () => {
+		expect(truncate("any string", 0)).toBe("...");
+	});
+
+	test("removes trailing whitespace before ellipsis", () => {
+		expect(truncate("hello world this", 11)).toBe("hello world...");
+	});
+});
+
+describe("formatAge", () => {
+	test("formats days as Xd", () => {
+		expect(formatAge(12)).toBe("12d");
+	});
+
+	test("formats 0 days as <1d", () => {
+		expect(formatAge(0)).toBe("<1d");
+	});
+
+	test("formats fractional days as hours when < 1", () => {
+		expect(formatAge(0.5)).toBe("12h");
+	});
+
+	test("formats very small values as minutes", () => {
+		// 0.02 days = 0.48 hours = 28.8 minutes -> floors to 28m
+		expect(formatAge(0.02)).toBe("28m");
+	});
+
+	test("formats exactly 1 day", () => {
+		expect(formatAge(1)).toBe("1d");
+	});
+
+	test("handles large numbers", () => {
+		expect(formatAge(365)).toBe("365d");
+	});
+});
+
+describe("formatDecay", () => {
+	test("formats decay as percentage", () => {
+		expect(formatDecay(91)).toBe("91%");
+	});
+
+	test("formats 100% decay", () => {
+		expect(formatDecay(100)).toBe("100%");
+	});
+
+	test("formats 0% decay", () => {
+		expect(formatDecay(0)).toBe("0%");
+	});
+
+	test("rounds decimal percentages", () => {
+		expect(formatDecay(91.5)).toBe("92%");
+	});
+
+	test("handles fractional percentages", () => {
+		expect(formatDecay(0.5)).toBe("1%");
+	});
+});
+
+describe("formatScore", () => {
+	test("formats score with 2 decimal places", () => {
+		expect(formatScore(0.57)).toBe("0.57");
+	});
+
+	test("formats score of 1.0", () => {
+		expect(formatScore(1.0)).toBe("1.00");
+	});
+
+	test("formats score of 0", () => {
+		expect(formatScore(0)).toBe("0.00");
+	});
+
+	test("rounds to 2 decimal places", () => {
+		expect(formatScore(0.567)).toBe("0.57");
+	});
+
+	test("handles very small scores", () => {
+		expect(formatScore(0.001)).toBe("0.00");
+	});
+});
+
+// ============================================================================
+// Memory Result Formatter Tests
+// ============================================================================
+
+describe("formatMemoryResults", () => {
+	const sampleResults: MemoryResult[] = [
+		{
+			id: "abc123",
+			score: 0.57,
+			age_days: 12,
+			decay_percent: 91,
+			content: "OAuth refresh tokens need 5min buffer before expiry",
+		},
+		{
+			id: "def456",
+			score: 0.56,
+			age_days: 1,
+			decay_percent: 99,
+			content: "Next.js cache components gotcha with useSearchParams",
+		},
+		{
+			id: "ghi789",
+			score: 0.55,
+			age_days: 9,
+			decay_percent: 93,
+			content: "Zod async validation anti-pattern causes blocking",
+			collection: "patterns",
+		},
+	];
+
+	test("formats results with header and count", () => {
+		const result = formatMemoryResults(sampleResults, "auth tokens");
+		expect(result).toContain("📚 Semantic Memory");
+		expect(result).toContain("3 results");
+	});
+
+	test("includes memory IDs in brackets", () => {
+		const result = formatMemoryResults(sampleResults, "test");
+		expect(result).toContain("[abc123]");
+		expect(result).toContain("[def456]");
+		expect(result).toContain("[ghi789]");
+	});
+
+	test("includes score, decay, and age", () => {
+		const result = formatMemoryResults(sampleResults, "test");
+		expect(result).toContain("score: 0.57");
+		expect(result).toContain("decay: 91%");
+		expect(result).toContain("12d");
+	});
+
+	test("truncates long content", () => {
+		const longContent: MemoryResult[] = [
+			{
+				id: "long1",
+				score: 0.5,
+				age_days: 1,
+				decay_percent: 99,
+				content:
+					"This is a very long piece of content that goes on and on and should definitely be truncated at some point to fit in the compact display format",
+			},
+		];
+		const result = formatMemoryResults(longContent, "test");
+		expect(result).toContain("...");
+		// Should not contain the full text
+		expect(result).not.toContain("compact display format");
+	});
+
+	test("handles empty results", () => {
+		const result = formatMemoryResults([], "nothing");
+		expect(result).toContain("0 results");
+		expect(result).toContain("nothing");
+	});
+
+	test("indents each result line", () => {
+		const result = formatMemoryResults(sampleResults, "test");
+		// Each result line should start with spaces for indentation
+		const lines = result.split("\n").filter((l) => l.includes("["));
+		for (const line of lines) {
+			expect(line.startsWith("  ")).toBe(true);
+		}
+	});
+
+	test("shows collection when provided", () => {
+		const withCollection: MemoryResult[] = [
+			{
+				id: "col1",
+				score: 0.5,
+				age_days: 1,
+				decay_percent: 99,
+				content: "Test",
+				collection: "my-collection",
+			},
+		];
+		const result = formatMemoryResults(withCollection, "test");
+		expect(result).toContain("my-collection");
+	});
+});
+
+// ============================================================================
+// CASS Result Formatter Tests
+// ============================================================================
+
+describe("formatCassResults", () => {
+	const sampleResults: CassResult[] = [
+		{
+			agent: "claude",
+			path: "~/.claude/sessions/abc.jsonl",
+			line: 42,
+			preview: "auth token refresh pattern with retry",
+		},
+		{
+			agent: "cursor",
+			path: "~/.cursor/sessions/def.jsonl",
+			line: 89,
+			preview: "similar authentication pattern found here",
+		},
+		{
+			agent: "opencode",
+			path: "~/.opencode/sessions/ghi.jsonl",
+			line: 156,
+			preview: "OAuth implementation discussion",
+		},
+	];
+
+	test("formats results with header and count", () => {
+		const result = formatCassResults(sampleResults, "auth", 5);
+		expect(result).toContain("🔍 CASS Search");
+		expect(result).toContain("3 results");
+	});
+
+	test("shows total when different from displayed", () => {
+		const result = formatCassResults(sampleResults, "auth", 10);
+		expect(result).toContain("10 total");
+	});
+
+	test("includes agent name in brackets", () => {
+		const result = formatCassResults(sampleResults, "test", 3);
+		expect(result).toContain("[claude]");
+		expect(result).toContain("[cursor]");
+		expect(result).toContain("[opencode]");
+	});
+
+	test("includes path and line number", () => {
+		const result = formatCassResults(sampleResults, "test", 3);
+		expect(result).toContain("abc.jsonl:42");
+		expect(result).toContain("def.jsonl:89");
+	});
+
+	test("includes preview in quotes", () => {
+		const result = formatCassResults(sampleResults, "test", 3);
+		expect(result).toContain('"auth token refresh');
+	});
+
+	test("truncates long previews", () => {
+		const longPreview: CassResult[] = [
+			{
+				agent: "claude",
+				path: "~/.claude/sessions/abc.jsonl",
+				line: 1,
+				preview:
+					"This is a very long preview that goes on and on and should be truncated at some point to fit nicely",
+			},
+		];
+		const result = formatCassResults(longPreview, "test", 1);
+		expect(result).toContain("...");
+	});
+
+	test("handles empty results", () => {
+		const result = formatCassResults([], "nothing", 0);
+		expect(result).toContain("0 results");
+	});
+
+	test("indents each result line", () => {
+		const result = formatCassResults(sampleResults, "test", 3);
+		const lines = result.split("\n").filter((l) => l.includes("["));
+		for (const line of lines) {
+			expect(line.startsWith("  ")).toBe(true);
+		}
+	});
+
+	test("shows shortened path with directory context", () => {
+		const homeResults: CassResult[] = [
+			{
+				agent: "claude",
+				path: "/Users/zacjones/.claude/sessions/abc.jsonl",
+				line: 1,
+				preview: "test",
+			},
+		];
+		const result = formatCassResults(homeResults, "test", 1);
+		// Should include directory context and filename
+		expect(result).toContain("sessions/abc.jsonl:1");
+	});
+});

--- a/packages/opencode-swarm-plugin/src/result-formatter.ts
+++ b/packages/opencode-swarm-plugin/src/result-formatter.ts
@@ -1,0 +1,264 @@
+/**
+ * Result Formatter Utilities
+ *
+ * Shared formatting functions for displaying tool results in a compact, scannable format.
+ * Used by semantic-memory_find, cass_search, and similar tools.
+ *
+ * Output style inspired by OpenCode subagent UI - concise, information-dense,
+ * with consistent visual hierarchy.
+ */
+
+import * as path from "node:path";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Semantic memory search result
+ */
+export interface MemoryResult {
+	/** Short ID for the memory (e.g., "abc123") */
+	id: string;
+	/** Similarity/relevance score (0-1) */
+	score: number;
+	/** Age in days since creation */
+	age_days: number;
+	/** Decay percentage (0-100, higher = more retained) */
+	decay_percent: number;
+	/** Memory content text */
+	content: string;
+	/** Optional collection name */
+	collection?: string;
+}
+
+/**
+ * CASS (Cross-Agent Session Search) result
+ */
+export interface CassResult {
+	/** Agent that produced this session (e.g., "claude", "cursor") */
+	agent: string;
+	/** Path to the session file */
+	path: string;
+	/** Line number in the session file */
+	line: number;
+	/** Preview snippet of the matched content */
+	preview: string;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Truncate text to a maximum length, adding ellipsis if truncated.
+ *
+ * @param text - Text to truncate
+ * @param maxLen - Maximum length (not counting ellipsis)
+ * @returns Truncated text with ellipsis if needed
+ *
+ * @example
+ * truncate("hello world", 5)  // "hello..."
+ * truncate("hi", 10)          // "hi"
+ */
+export function truncate(text: string, maxLen: number): string {
+	if (text.length <= maxLen) {
+		return text;
+	}
+
+	// Truncate and remove trailing whitespace
+	const truncated = text.slice(0, maxLen).trimEnd();
+	return `${truncated}...`;
+}
+
+/**
+ * Format age in days to a compact human-readable string.
+ *
+ * @param days - Age in days (can be fractional)
+ * @returns Formatted string like "12d", "3h", "5m"
+ *
+ * @example
+ * formatAge(12)    // "12d"
+ * formatAge(0.5)   // "12h"
+ * formatAge(0.02)  // "29m"
+ * formatAge(0)     // "<1d"
+ */
+export function formatAge(days: number): string {
+	if (days === 0) {
+		return "<1d";
+	}
+
+	if (days >= 1) {
+		return `${Math.floor(days)}d`;
+	}
+
+	// Less than 1 day - show hours
+	const hours = days * 24;
+	if (hours >= 1) {
+		return `${Math.floor(hours)}h`;
+	}
+
+	// Less than 1 hour - show minutes
+	const minutes = hours * 60;
+	return `${Math.floor(minutes)}m`;
+}
+
+/**
+ * Format decay percentage with visual indicator.
+ *
+ * @param percent - Decay percentage (0-100)
+ * @returns Formatted string like "91%"
+ *
+ * @example
+ * formatDecay(91)    // "91%"
+ * formatDecay(100)   // "100%"
+ * formatDecay(0.5)   // "1%"
+ */
+export function formatDecay(percent: number): string {
+	return `${Math.round(percent)}%`;
+}
+
+/**
+ * Format a similarity/relevance score.
+ *
+ * @param score - Score value (typically 0-1)
+ * @returns Formatted string with 2 decimal places
+ *
+ * @example
+ * formatScore(0.57)   // "0.57"
+ * formatScore(1.0)    // "1.00"
+ * formatScore(0.567)  // "0.57"
+ */
+export function formatScore(score: number): string {
+	return score.toFixed(2);
+}
+
+/**
+ * Get the last N path components from a file path
+ *
+ * @param filePath - Full file path
+ * @param components - Number of path components to include (default 2)
+ * @returns Shortened path with last N components
+ */
+function getShortPath(filePath: string, components: number = 2): string {
+	const parts = filePath.split(path.sep).filter(Boolean);
+	if (parts.length <= components) {
+		return parts.join("/");
+	}
+	return parts.slice(-components).join("/");
+}
+
+// ============================================================================
+// Memory Result Formatter
+// ============================================================================
+
+/** Maximum length for content preview in memory results */
+const MEMORY_CONTENT_MAX_LEN = 60;
+
+/**
+ * Format semantic memory search results in a compact list style.
+ *
+ * Output format:
+ * ```
+ * 📚 Semantic Memory (3 results for "auth tokens"):
+ *   [abc123] OAuth refresh tokens need 5min buffer... (score: 0.57, decay: 91%, 12d)
+ *   [def456] Next.js cache components gotcha... (score: 0.56, decay: 99%, 1d)
+ *   [ghi789] Zod async validation anti-pattern... (score: 0.55, decay: 93%, 9d) [patterns]
+ * ```
+ *
+ * @param results - Array of memory search results
+ * @param query - The search query (for display in header)
+ * @returns Formatted string ready for display
+ */
+export function formatMemoryResults(
+	results: MemoryResult[],
+	query: string,
+): string {
+	const count = results.length;
+	const lines: string[] = [];
+
+	// Header
+	lines.push(`📚 Semantic Memory (${count} results for "${query}"):`);
+
+	if (count === 0) {
+		lines.push("  No matching memories found.");
+		return lines.join("\n");
+	}
+
+	// Each result
+	for (const result of results) {
+		const id = result.id;
+		const content = truncate(result.content, MEMORY_CONTENT_MAX_LEN);
+		const score = formatScore(result.score);
+		const decay = formatDecay(result.decay_percent);
+		const age = formatAge(result.age_days);
+
+		let line = `  [${id}] ${content} (score: ${score}, decay: ${decay}, ${age})`;
+
+		// Add collection tag if present
+		if (result.collection && result.collection !== "default") {
+			line += ` [${result.collection}]`;
+		}
+
+		lines.push(line);
+	}
+
+	return lines.join("\n");
+}
+
+// ============================================================================
+// CASS Result Formatter
+// ============================================================================
+
+/** Maximum length for preview text in CASS results */
+const CASS_PREVIEW_MAX_LEN = 50;
+
+/**
+ * Format CASS (Cross-Agent Session Search) results in a compact list style.
+ *
+ * Output format:
+ * ```
+ * 🔍 CASS Search (3 results for "auth", 10 total):
+ *   [claude] abc.jsonl:42 - "auth token refresh pattern..."
+ *   [cursor] def.jsonl:89 - "similar authentication..."
+ *   [opencode] ghi.jsonl:156 - "OAuth implementation..."
+ * ```
+ *
+ * @param results - Array of CASS search results
+ * @param query - The search query (for display in header)
+ * @param total - Total number of matches (may differ from displayed count due to limit)
+ * @returns Formatted string ready for display
+ */
+export function formatCassResults(
+	results: CassResult[],
+	query: string,
+	total: number,
+): string {
+	const count = results.length;
+	const lines: string[] = [];
+
+	// Header with total if different from displayed count
+	let header = `🔍 CASS Search (${count} results for "${query}"`;
+	if (total > count) {
+		header += `, ${total} total`;
+	}
+	header += "):";
+	lines.push(header);
+
+	if (count === 0) {
+		lines.push("  No matching sessions found.");
+		return lines.join("\n");
+	}
+
+	// Each result
+	for (const result of results) {
+		const agent = result.agent;
+		const shortPath = getShortPath(result.path);
+		const line = result.line;
+		const preview = truncate(result.preview, CASS_PREVIEW_MAX_LEN);
+
+		lines.push(`  [${agent}] ${shortPath}:${line} - "${preview}"`);
+	}
+
+	return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

Adds compact, scannable list rendering for `semantic-memory_find` and `cass_search` tool outputs, inspired by OpenCode's subagent UI style.

## Changes

- **New `result-formatter.ts`**: Shared utility for formatting tool outputs
- **`semantic-memory_find`**: Now displays results in compact format with score, decay %, and age
- **`cass_search`**: Now displays results with agent, path:line, and preview

## Before/After

### semantic-memory_find

**Before:** Raw JSON output
**After:**
```
📚 Semantic Memory (3 results for "auth tokens"):
  [abc123] OAuth refresh tokens need 5min buffer... (score: 0.57, decay: 91%, 12d)
  [def456] Next.js cache components gotcha... (score: 0.56, decay: 99%, 1d)
```

### cass_search

**Before:** Verbose structured output
**After:**
```
🔍 CASS Search (5 results for "auth tokens"):
  [claude] sessions/abc.jsonl:42 - "auth token refresh..."
  [cursor] history/def.jsonl:89 - "similar pattern..."
```

## Test Coverage

- 38 new tests for result-formatter
- Updated tests for memory-tools and cass-tools
- All 60+ tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compact, readable formatting for semantic memory search results displaying score, decay percentage, and age
  * Compact, readable formatting for CASS search results displaying agent, file path, and preview
  * Memory decay calculations for tracking result freshness

* **Tests**
  * Added comprehensive test coverage for new formatting utilities and memory decay calculations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->