### PR TITLE
fix: correct global skills directory path in swarm doctor

### DIFF
--- a/packages/opencode-swarm-plugin/bin/swarm.ts
+++ b/packages/opencode-swarm-plugin/bin/swarm.ts
@@ -1680,7 +1680,7 @@ async function doctor(debug = false) {
   // Check skills
   p.log.step("Skills:");
   const configDir = join(homedir(), ".config", "opencode");
-  const globalSkillsPath = join(configDir, "skills");
+  const globalSkillsPath = join(configDir, "skill");
   const bundledSkillsPath = join(__dirname, "..", "global-skills");
 
   // Global skills directory


### PR DESCRIPTION
- Changed globalSkillsPath from 'skills' to 'skill' (singular)
- Matches correct OpenCode directory name: ~/.config/opencode/skill/
- Reference: src/skills.ts line 252 already uses correct path
- Fixes swarm doctor checking for wrong directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the directory path used by the diagnostic tool when detecting globally installed skills.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->