### PR TITLE
fix: correct global skills directory path in swarm doctor

### DIFF
--- a/packages/opencode-swarm-plugin/bin/swarm.ts
+++ b/packages/opencode-swarm-plugin/bin/swarm.ts
@@ -2740,7 +2740,7 @@ function config() {
   const plannerAgentPath = join(agentDir, "swarm-planner.md");
   const workerAgentPath = join(agentDir, "swarm-worker.md");
   const researcherAgentPath = join(agentDir, "swarm-researcher.md");
-  const globalSkillsPath = join(configDir, "skills");
+  const globalSkillsPath = join(configDir, "skill");
 
   console.log(yellow(BANNER));
   console.log(dim("  " + TAGLINE + " v" + VERSION));


### PR DESCRIPTION
Fixed the directory path used by the diagnostic tool when detecting globally installed skills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the global skills directory path reference to ensure the system properly locates and loads global skills in the swarm plugin.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->