### PR TITLE
fix(hive): add description support for epic subtasks

### DIFF
--- a/packages/opencode-swarm-plugin/src/hive.ts
+++ b/packages/opencode-swarm-plugin/src/hive.ts
@@ -786,6 +786,7 @@ export const hive_create_epic = tool({
           type: "task",
           priority: subtask.priority ?? 2,
           parent_id: epic.id,
+          description: subtask.description,
         });
         await adapter.markDirty(projectKey, subtaskCell.id);
         created.push(subtaskCell);

--- a/packages/opencode-swarm-plugin/src/schemas/cell.ts
+++ b/packages/opencode-swarm-plugin/src/schemas/cell.ts
@@ -185,6 +185,7 @@ export const EpicCreateArgsSchema = z.object({
     .array(
       z.object({
         title: z.string().min(1),
+        description: z.string().optional(),
         priority: z.number().int().min(0).max(3).default(2),
         files: z.array(z.string()).optional().default([]),
         /**

--- a/packages/opencode-swarm-plugin/src/schemas/index.test.ts
+++ b/packages/opencode-swarm-plugin/src/schemas/index.test.ts
@@ -80,6 +80,30 @@ describe("EpicCreateArgsSchema", () => {
     };
     expect(() => EpicCreateArgsSchema.parse(args)).toThrow();
   });
+
+  it("validates subtask with description", () => {
+    const args = {
+      epic_title: "Big feature",
+      subtasks: [
+        { title: "Part 1", priority: 2, description: "First part does X" },
+        { title: "Part 2", priority: 3, description: "Second part does Y" },
+      ],
+    };
+    const result = EpicCreateArgsSchema.parse(args);
+    expect(result.subtasks[0].description).toBe("First part does X");
+    expect(result.subtasks[1].description).toBe("Second part does Y");
+  });
+
+  it("allows subtask without description", () => {
+    const args = {
+      epic_title: "Big feature",
+      subtasks: [
+        { title: "Part 1", priority: 2 },
+      ],
+    };
+    const result = EpicCreateArgsSchema.parse(args);
+    expect(result.subtasks[0].description).toBeUndefined();
+  });
 });
 
 describe("EvaluationSchema", () => {


### PR DESCRIPTION
## Summary

- Add `description` field to `EpicCreateArgsSchema` subtasks schema
- Pass `subtask.description` to `adapter.createCell()` in `hive_create_epic`

## Problem

When creating epics with subtasks via `hive_create_epic`, subtask descriptions were silently dropped because:

1. `EpicCreateArgsSchema` didn't include `description` in its subtasks array schema (even though `SubtaskSpecSchema` had it)
2. `hive_create_epic` wasn't passing `description` to `adapter.createCell()`

## Changes

| File | Change |
|------|--------|
| `schemas/cell.ts` | Add `description: z.string().optional()` to subtasks schema |
| `hive.ts` | Pass `description: subtask.description` in `createCell()` call |
| `schemas/index.test.ts` | Unit tests for schema validation |
| `hive.integration.test.ts` | Integration test for description persistence |

## Testing

- Unit test: validates schema accepts description field
- Unit test: validates schema allows subtasks without description (backward compat)
- Integration test: verifies descriptions are persisted via adapter

All tests pass:
```
bun test src/schemas/index.test.ts  # 16 pass
bun test src/hive.integration.test.ts -t "hive_create_epic"  # 5 pass
```

Fixes #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subtasks can now include optional descriptions when creating epics. Descriptions are properly persisted and retrievable for each subtask.

* **Tests**
  * Added integration tests verifying subtask descriptions are correctly created and stored.
  * Added schema validation tests confirming descriptions are optional and properly parsed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->