### PR TITLE
fix: force WAL checkpoint after hive write operations

### DIFF
--- a/packages/opencode-swarm-plugin/src/hive.ts
+++ b/packages/opencode-swarm-plugin/src/hive.ts
@@ -676,6 +676,16 @@ export const hive_create = tool({
         projectKey,
       );
 
+      // Force WAL checkpoint to ensure data durability
+      // Ensures cell is visible to other processes (e.g., spawned workers)
+      // See: https://github.com/joelhooks/swarm-tools/issues/147
+      try {
+        await adapter.sync();
+      } catch (syncError) {
+        // Non-fatal - log and continue
+        console.warn("[hive_create] Failed to sync WAL checkpoint:", syncError);
+      }
+
       const formatted = formatCellForOutput(cell);
       return JSON.stringify(formatted, null, 2);
     } catch (error) {
@@ -901,6 +911,20 @@ export const hive_create_epic = tool({
         // Non-fatal - log and continue
         console.warn(
           "[hive_create_epic] Failed to sync to JSONL:",
+          error,
+        );
+      }
+
+      // Force WAL checkpoint to ensure data durability
+      // Critical for multi-process scenarios - cells created here must be visible
+      // to spawned workers who connect to the same database
+      // See: https://github.com/joelhooks/swarm-tools/issues/147
+      try {
+        await adapter.sync();
+      } catch (error) {
+        // Non-fatal - log and continue
+        console.warn(
+          "[hive_create_epic] Failed to sync WAL checkpoint:",
           error,
         );
       }
@@ -1263,6 +1287,16 @@ export const hive_close = tool({
         "hive_close",
         projectKey,
       );
+
+      // Force WAL checkpoint to ensure data durability
+      // Ensures cell closure is visible to other processes
+      // See: https://github.com/joelhooks/swarm-tools/issues/147
+      try {
+        await adapter.sync();
+      } catch (syncError) {
+        // Non-fatal - log and continue
+        console.warn("[hive_close] Failed to sync WAL checkpoint:", syncError);
+      }
 
       return `Closed ${cell.id}: ${validated.reason}`;
     } catch (error) {

--- a/packages/swarm-mail/src/hive/adapter.ts
+++ b/packages/swarm-mail/src/hive/adapter.ts
@@ -812,13 +812,32 @@ export function createHiveAdapter(
       return db;
     },
 
+    async sync(projectPath?) {
+      // Force WAL checkpoint to ensure data durability
+      // Critical for multi-process scenarios (e.g., MCP server spawning sub-agents)
+      // Without this, data written by one process may not be visible to another
+      // See: https://github.com/joelhooks/swarm-tools/issues/147
+      if (db.checkpoint) {
+        await db.checkpoint();
+      }
+    },
+
     async close(projectPath?) {
+      // Force checkpoint before close to prevent data loss
+      // Ensures any uncommitted WAL frames are flushed
+      if (db.checkpoint) {
+        await db.checkpoint();
+      }
       if (db.close) {
         await db.close();
       }
     },
 
     async closeAll() {
+      // Force checkpoint before close to prevent data loss
+      if (db.checkpoint) {
+        await db.checkpoint();
+      }
       if (db.close) {
         await db.close();
       }

--- a/packages/swarm-mail/src/types/hive-adapter.ts
+++ b/packages/swarm-mail/src/types/hive-adapter.ts
@@ -703,6 +703,29 @@ export interface HiveAdapter
   getDatabase(projectPath?: string): Promise<DatabaseAdapter>;
 
   /**
+   * Force WAL checkpoint to ensure data durability
+   * 
+   * Call after batch operations (epic creation, bulk updates) to ensure
+   * data written by this process is visible to other processes.
+   * 
+   * This fixes data loss when MCP server process restarts - cells created
+   * by one process instance may sit in the WAL journal and be rolled back
+   * when the process dies without clean shutdown.
+   * 
+   * @see https://github.com/joelhooks/swarm-tools/issues/147
+   * 
+   * @example
+   * ```typescript
+   * // After creating an epic with subtasks
+   * await hive.createCell(projectKey, { title: 'Epic', type: 'epic' });
+   * await hive.createCell(projectKey, { title: 'Task 1', type: 'task', parent_id: epicId });
+   * await hive.createCell(projectKey, { title: 'Task 2', type: 'task', parent_id: epicId });
+   * await hive.sync(); // Force checkpoint to ensure durability
+   * ```
+   */
+  sync(projectPath?: string): Promise<void>;
+
+  /**
    * Close the database connection
    * 
    * Note: This is shared with SwarmMailAdapter, so closing should be coordinated


### PR DESCRIPTION
## Problem

Fixes #147 - SQLite WAL journal loss: hive cells vanish after MCP process restart

When the MCP server process spawns sub-agents, data written by one process may not be visible to another because:
1. Data sits in the WAL journal
2. When the writing process crashes or exits without clean shutdown, transactions might roll back
3. New processes can't see uncommitted WAL frames

This caused cells created via `hive_create` or `hive_create_epic` to silently vanish when workers tried to access them 3-15 minutes later.

## Root Cause

The database uses SQLite WAL mode but never forces checkpoints after write operations. All data accumulates in the WAL journal. When the MCP server process restarts (e.g., when spawning sub-agents), the new process may:
- Cannot read uncommitted WAL frames from the prior process (write lock died without clean shutdown → transaction rollback)
- Reset the WAL during recovery, rolling back in-progress transactions

## Solution

This PR adds:

1. **`sync()` method to HiveAdapter interface** - Forces a WAL checkpoint via `PRAGMA wal_checkpoint(TRUNCATE)`

2. **Implementation in adapter factory**:
   - `sync()` calls `db.checkpoint()` if available
   - `close()` and `closeAll()` now checkpoint before closing to prevent data loss

3. **Automatic sync after critical write operations**:
   - `hive_create` - individual cell creation
   - `hive_create_epic` - batch epic + subtasks creation  
   - `hive_close` - cell closure

The sync() operation is non-fatal - if it fails, we log a warning and continue. This ensures the fix doesn't break existing workflows while improving durability.

## Impact

This fix ensures reliable multi-agent coordination where data written by one process (coordinator creating epic + subtasks) is guaranteed to be visible to other processes (spawned workers accessing those cells).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit data synchronization capability to persist uncommitted data changes.

* **Improvements**
  * Enhanced data durability for core hive operations through automatic synchronization checkpoints, improving data visibility across processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->