### PR TITLE
feat: improve skill scores across swarm-tools

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: release
-description: |
-  Handles version bumps and npm releases for the swarm-tools monorepo (opencode-swarm-plugin,
-  claude-code-swarm-plugin, swarm-mail, swarm-queue). Use when: creating changesets, bumping
-  versions, preparing releases, checking release status, debugging publish failures, verifying
-  npm packages, or merging release PRs.
-  Triggers: "release", "publish", "changeset", "bump version", "ship it", "new version",
-  "create a release", "check npm", "verify publish", "/release"
+description: "Handles version bumps and npm releases for the swarm-tools monorepo (opencode-swarm-plugin, claude-code-swarm-plugin, swarm-mail, swarm-queue). Use when creating changesets, bumping versions, preparing releases, checking release status, debugging publish failures, verifying npm packages, or merging release PRs. Triggers: release, publish, changeset, bump version, ship it, new version, create a release, check npm, verify publish, /release."
 ---
 
 # Release Workflow

--- a/.opencode/skill/gh-issue-triage/SKILL.md
+++ b/.opencode/skill/gh-issue-triage/SKILL.md
@@ -1,18 +1,6 @@
 ---
 name: gh-issue-triage
-description: GitHub issue triage workflow with contributor profile extraction. Analyze → clarify → file cells → tag → implement → credit. Captures Twitter handles for changeset acknowledgments.
-tags:
-  - github
-  - issues
-  - triage
-  - contributors
-  - twitter
-  - credits
----
-
----
-name: gh-issue-triage
-description: GitHub issue triage workflow with contributor profile extraction. Analyze → clarify → file cells → tag → implement → credit. Captures Twitter handles for changeset acknowledgments.
+description: "Use when triaging GitHub issues to analyze, clarify, label, and implement fixes while crediting contributors. Fetches contributor profiles including Twitter handles, files hive cells for tracking, applies labels via gh CLI, and generates changeset acknowledgments. Handles bugs, feature requests, duplicates, and support questions with appropriate workflows for each issue type."
 tags:
   - github
   - issues

--- a/.opencode/skill/pr-triage/SKILL.md
+++ b/.opencode/skill/pr-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-triage
-description: "Context-efficient PR comment triage. Evaluate, decide, act. Fix important issues, resolve the rest silently."
+description: "Use when triaging pull request review comments to decide which need code fixes and which to resolve silently. Fetches unreplied PR comments, evaluates each for security or correctness issues, applies fixes with commit references for important problems, and resolves style nits and metadata comments without reply. Prioritizes action over conversation to keep PR threads focused."
 tags:
   - pr
   - review

--- a/.opencode/skill/tdd/SKILL.md
+++ b/.opencode/skill/tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: "Test-Driven Development workflow with RED-GREEN-REFACTOR, lore from Kent Beck, Michael Feathers, and Ousterhout's counterpoint"
+description: "Use when writing code test-first using TDD and the RED-GREEN-REFACTOR cycle. Write a failing test that defines expected behavior, implement minimal code to pass, then refactor while keeping tests green. Applies test-driven development patterns including triangulation, fake-it-til-you-make-it, and assertion-first design. Draws on practices from Kent Beck, Michael Feathers, and balances with Ousterhout's design-first counterpoint."
 tags:
   - testing
   - workflow

--- a/packages/claude-code-swarm-plugin/skills/always-on-guidance/SKILL.md
+++ b/packages/claude-code-swarm-plugin/skills/always-on-guidance/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: always-on-guidance
-description: |
-  Always-on rule-oriented guidance for claude-plugin agents. Use to align behavior,
-  tool usage, and model-specific defaults while avoiding deprecated bd/cass references.
-  Related skills: swarm-coordination, testing-patterns.
+description: "Always-on rule-oriented guidance for claude-plugin agents. Use when configuring agent behavior defaults, enforcing tool usage conventions, selecting model-specific output styles, or ensuring deprecated bd (BeadDB CLI) and cass (Coding Agent Session Search) references are replaced with current swarm-mail APIs. Covers instruction priority, file reservation discipline, model aliases, and testing workflow. Related skills: swarm-coordination, testing-patterns."
 ---
 
 # Always-On Guidance
@@ -13,6 +10,14 @@ description: |
 - Follow instruction priority: system → developer → user → AGENTS.
 - Use swarm plugin tools (`hive_*`, `swarm_*`, `swarmmail_*`, `hivemind_*`); avoid deprecated `bd`/`cass` references.
 - Stay within assigned files; reserve before edits with `ttl_seconds`; release reservations on done; finish swarm work with `swarm_complete`.
+
+  Example reserve→edit→release flow:
+  ```
+  swarmmail_reserve({ files: ["src/auth.ts"], ttl_seconds: 300 })
+  # ... edit src/auth.ts ...
+  swarm_complete({ bead_id: "cell-abc123", status: "done" })  # auto-releases reservations
+  ```
+
 - Use `TaskCreate`/`TaskUpdate` for visible progress in Claude Code UI alongside `hive_*` for git-backed persistence.
 - When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is enabled, prefer `TeammateTool` for real-time coordination and `swarmmail_*` for persistence.
 - `swarmmail_release_all` is coordinator-only for stale/orphaned reservations.

--- a/packages/claude-code-swarm-plugin/skills/openclaw-messaging/SKILL.md
+++ b/packages/claude-code-swarm-plugin/skills/openclaw-messaging/SKILL.md
@@ -160,3 +160,10 @@ openclaw system event --mode now --text "Completed Phase 1 encryption. All tests
 ```bash
 openclaw system event --mode now --text "Worker task-42 complete: implemented D1 schema migration. 12 tests added."
 ```
+
+### Verifying message delivery
+Use `--json` output to confirm delivery status. For critical notifications, check the response for success before proceeding:
+```bash
+openclaw message send --channel telegram --target @joelhooks -m "Deploy complete" --json
+# Response includes delivery status — check "status": "delivered" before continuing workflow
+```

--- a/packages/claude-code-swarm-plugin/skills/swarm-coordination/SKILL.md
+++ b/packages/claude-code-swarm-plugin/skills/swarm-coordination/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: swarm-coordination
-description: |
-  Multi-agent coordination patterns for OpenCode swarm workflows. Use when work
-  benefits from parallelization or coordination. Covers: decomposition, worker
-  spawning, file reservations, progress tracking, and review loops.
+description: "Multi-agent coordination patterns for OpenCode swarm workflows. Use when you need to split work across agents, parallelize tasks, coordinate file ownership, or run a swarm. Covers: task decomposition, worker spawning, file reservations, progress tracking, and review loops."
 ---
 
 # Swarm Coordination
@@ -18,10 +15,6 @@ This skill guides multi-agent coordination for OpenCode swarm workflows.
 - Time-to-completion matters
 
 Avoid swarming for 1–2 file changes or tightly sequential work.
-
-## Tool Access (Wildcard)
-
-This skill is configured with `tools: ["*"]` per user choice. If you need curated access later, replace the wildcard with explicit tool lists.
 
 ## Foreground vs Background vs Agent Teams
 

--- a/packages/opencode-swarm-plugin/claude-plugin/skills/always-on-guidance/SKILL.md
+++ b/packages/opencode-swarm-plugin/claude-plugin/skills/always-on-guidance/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: always-on-guidance
-description: |
-  Always-on rule-oriented guidance for claude-plugin agents. Use to align behavior,
-  tool usage, and model-specific defaults while avoiding deprecated bd/cass references.
-  Related skills: swarm-coordination, testing-patterns.
+description: "Always-on rule-oriented guidance for claude-plugin agents. Use when configuring agent behavior rules, enforcing correct tool usage (hive_*, swarm_*, swarmmail_*, hivemind_*), applying model-specific defaults for GPT-5.2-code or Opus 4.5, or preventing use of deprecated bd (BeadDB CLI) and cass (Coding Agent Session Search legacy API) references. Covers instruction priority, file reservation discipline, and testing workflow. Related skills: swarm-coordination, testing-patterns."
 ---
 
 # Always-On Guidance
@@ -11,7 +8,7 @@ description: |
 ## Global Rules
 
 - Follow instruction priority: system → developer → user → AGENTS.
-- Use swarm plugin tools (`hive_*`, `swarm_*`, `swarmmail_*`, `hivemind_*`); avoid deprecated `bd`/`cass` references.
+- Use swarm plugin tools (`hive_*`, `swarm_*`, `swarmmail_*`, `hivemind_*`); avoid deprecated `bd` (BeadDB CLI, replaced by HiveAdapter) and `cass` (Coding Agent Session Search legacy API, replaced by hivemind_find) references.
 - Stay within assigned files; reserve before edits with `ttl_seconds`; release reservations on done; finish swarm work with `swarm_complete`.
 - After every `swarm_spawn_subtask`, immediately call `Task(subagent_type="swarm-worker", prompt="<prompt returned by swarm_spawn_subtask>")`.
 - `swarmmail_release_all` is coordinator-only for stale/orphaned reservations.

--- a/packages/opencode-swarm-plugin/claude-plugin/skills/ralph-supervisor/SKILL.md
+++ b/packages/opencode-swarm-plugin/claude-plugin/skills/ralph-supervisor/SKILL.md
@@ -1,15 +1,40 @@
 ---
 name: ralph-supervisor
-description: |
-  Ralph loop pattern - Claude supervises while Codex (gpt-5.3-codex) executes
-  implementation work. Use for autonomous coding loops with fresh context per
-  iteration, validation gates, and git-backed persistence. Tools: ralph_init,
-  ralph_story, ralph_iterate, ralph_loop, ralph_status, ralph_cancel, ralph_review.
+description: "Ralph loop pattern — Claude supervises while Codex (gpt-5.3-codex) executes implementation work. Use when running autonomous coding loops, delegating coding tasks to background agents, orchestrating sequential implementation with fresh context per iteration, or managing supervisor-executor workflows with validation gates and git-backed persistence. Trigger terms: delegate coding, background task, autonomous loop, supervisor pattern, codex execute. Tools: ralph_init, ralph_story, ralph_iterate, ralph_loop, ralph_status, ralph_cancel, ralph_review."
 ---
 
 # Ralph Supervisor Pattern
 
 Ralph implements an autonomous coding loop where Claude acts as supervisor and Codex executes implementation work. Named after the pattern from [openclaw-codex-ralph](https://github.com/joelhooks/openclaw-codex-ralph).
+
+## Quick Start
+
+Initialize a Ralph project, add a story, and start the autonomous loop:
+
+```typescript
+// 1. Initialize a new Ralph project
+ralph_init({ project_path: "/path/to/project", validation_command: "npm test && npm run typecheck" })
+
+// 2. Add a story to the PRD
+ralph_story({
+  title: "Add user authentication",
+  description: "Implement JWT-based login/logout with refresh tokens",
+  acceptance_criteria: ["JWT generation works", "Refresh token rotation implemented"],
+  validation_command: "npm test -- --grep auth"
+})
+
+// 3. Start the autonomous coding loop (Codex executes, Claude supervises)
+ralph_loop({ max_iterations: 10 })
+
+// 4. Check progress at any time
+ralph_status()
+
+// 5. Review completed work
+ralph_review({ approve: true })
+
+// 6. Cancel if needed
+ralph_cancel({ reason: "Changing approach" })
+```
 
 ## Core Philosophy
 

--- a/packages/opencode-swarm-plugin/claude-plugin/skills/swarm-cli/SKILL.md
+++ b/packages/opencode-swarm-plugin/claude-plugin/skills/swarm-cli/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: swarm-cli
-description: |
-  Swarm CLI commands for workers - hivemind memory, hive tasks, swarmmail coordination.
-  Use when working in a swarm context. Covers: swarm memory (find/store/get/stats),
-  swarm cells (query/create/update/close), and coordination commands.
+description: "Swarm CLI commands for workers covering hivemind memory, hive tasks, and swarmmail coordination. Use when working in a swarm context, managing distributed memory, or coordinating worker tasks. Covers: swarm memory (find/store/get/stats), swarm cells (query/create/update/close), and coordination commands."
 ---
 
 # Swarm CLI Quick Reference

--- a/packages/opencode-swarm-plugin/claude-plugin/skills/swarm-coordination/SKILL.md
+++ b/packages/opencode-swarm-plugin/claude-plugin/skills/swarm-coordination/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: swarm-coordination
-description: |
-  Multi-agent coordination patterns for OpenCode swarm workflows. Use when work
-  benefits from parallelization or coordination. Covers: decomposition, worker
-  spawning, file reservations, progress tracking, and review loops.
+description: "Multi-agent coordination patterns for OpenCode swarm workflows. Use when parallelizing tasks across multiple agents, coordinating worker spawning, managing file reservations, tracking progress across subtasks, or running review loops. Trigger terms: swarm, parallel tasks, spawn workers, coordinate agents, decompose work, multi-agent, delegate subtasks, fan out. Covers: decomposition, worker spawning, file reservations, progress tracking, and review loops."
 ---
 
 # Swarm Coordination

--- a/packages/opencode-swarm-plugin/examples/skill/hive-workflow/SKILL.md
+++ b/packages/opencode-swarm-plugin/examples/skill/hive-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hive-workflow
-description: Issue tracking and task management using the hive system. Use when creating, updating, or managing work items. Use when you need to track bugs, features, tasks, or epics. Do NOT use for simple one-off questions or explorations.
+description: "Issue tracking and task management using the hive system. Use when creating tickets, assigning priorities, updating status, closing resolved work items, or managing epics with subtasks. Use when you need to track bugs, features, tasks, or chores across a project. Do NOT use for simple one-off questions or explorations."
 tags:
   - hive
   - issues

--- a/packages/opencode-swarm-plugin/examples/skill/skill-creator/SKILL.md
+++ b/packages/opencode-swarm-plugin/examples/skill/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Guide for creating effective agent skills. Use when you want to create a new skill, improve an existing skill, or learn best practices for skill development. Helps codify learned patterns into reusable, discoverable skills.
+description: "Guide for creating effective agent skills. Use when writing YAML frontmatter, defining trigger terms, structuring workflow instructions, or adding bundled scripts and references. Use when you want to create a new skill, improve an existing skill, or codify learned patterns into reusable, discoverable skills."
 tags:
   - meta
   - skills

--- a/packages/opencode-swarm-plugin/examples/skill/swarm-coordination/SKILL.md
+++ b/packages/opencode-swarm-plugin/examples/skill/swarm-coordination/SKILL.md
@@ -1,10 +1,14 @@
 ---
 name: swarm-coordination
-description: Multi-agent coordination patterns for OpenCode swarm workflows. Use when working on complex tasks that benefit from parallelization, when coordinating multiple agents, or when managing task decomposition. Do NOT use for simple single-agent tasks.
+description: "Multi-agent coordination patterns for OpenCode swarm workflows. Use when spawning worker agents, distributing subtasks across parallel workers, reserving files to prevent conflicts, or routing messages between agents. Use when decomposing complex tasks, coordinating multiple agents, or orchestrating parallel execution. Do NOT use for simple single-agent tasks."
 tags:
   - swarm
   - multi-agent
   - coordination
+  - parallel
+  - decomposition
+  - orchestration
+  - task-distribution
 tools:
   - swarm_decompose
   - swarm_complete

--- a/packages/opencode-swarm-plugin/global-skills/cli-builder/SKILL.md
+++ b/packages/opencode-swarm-plugin/global-skills/cli-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli-builder
-description: Guide for building TypeScript CLIs with Bun. Use when creating command-line tools, adding subcommands to existing CLIs, or building developer tooling. Covers argument parsing, subcommand patterns, output formatting, and distribution.
+description: "Guide for building TypeScript CLIs with Bun. Use when creating command-line tools, adding subcommands to existing CLIs, or building developer tooling. Covers argument parsing, subcommand patterns, output formatting, and distribution."
 tags:
   - cli
   - typescript
@@ -12,13 +12,15 @@ tags:
 
 Build TypeScript command-line tools with Bun.
 
-## When to Build a CLI
+## CLI Build Workflow
 
-CLIs are ideal for:
-- Developer tools and automation
-- Project-specific commands (`swarm`, `bd`, etc.)
-- Scripts that need arguments/flags
-- Tools that compose with shell pipelines
+1. **Define the interface** - Identify commands, flags, and positional arguments the CLI needs
+2. **Set up the entry point** - Create the script with shebang and argument parsing
+3. **Implement subcommands** - Use the command registry pattern for multi-command CLIs
+4. **Add output formatting** - Support `--json` for scriptability and human-readable defaults
+5. **Handle errors gracefully** - Validate inputs early, use meaningful exit codes
+6. **Add help text** - Provide `--help` for every command and subcommand
+7. **Configure distribution** - Set up `bin` field in package.json and build step
 
 ## Quick Start
 

--- a/packages/opencode-swarm-plugin/global-skills/learning-systems/SKILL.md
+++ b/packages/opencode-swarm-plugin/global-skills/learning-systems/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: learning-systems
-description: Implicit feedback scoring, confidence decay, and anti-pattern detection. Use when understanding how the swarm plugin learns from outcomes, implementing learning loops, or debugging why patterns are being promoted or deprecated. Unique to opencode-swarm-plugin.
+description: "Score task outcomes from duration, errors, and retries to compute implicit feedback. Apply confidence decay using half-life formulas to fade stale patterns. Detect and invert anti-patterns when failure rates exceed thresholds. Use when recording swarm outcomes, debugging pattern promotion or deprecation, tuning learning thresholds, or implementing feedback loops. Unique to opencode-swarm-plugin."
+tags:
+  - learning
+  - feedback
+  - patterns
+  - anti-patterns
+  - scoring
+  - decay
+  - maturity
 ---
 
 # Learning Systems

--- a/packages/opencode-swarm-plugin/global-skills/queue/SKILL.md
+++ b/packages/opencode-swarm-plugin/global-skills/queue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: queue
-description: Guide for job queue patterns in multi-agent coordination. Use when deciding between background jobs vs inline execution, submitting long-running tasks, monitoring job progress, and handling failures. Covers when to queue, job priority, retry strategies, and monitoring patterns.
+description: "Implements job queue patterns for multi-agent coordination using BullMQ and Redis. Use when submitting background jobs, configuring retry strategies, setting job priority levels, monitoring queue health metrics, or handling dead-letter failures. Use when deciding between background jobs vs inline execution, creating workers with concurrency settings, chaining dependent jobs, or polling for job completion. Covers queue creation, job submission, worker processing, exponential backoff, graceful degradation, and performance tuning."
 tags:
   - queue
   - background-jobs
@@ -456,6 +456,16 @@ if (metrics.failed > 0) {
   }
 }
 ```
+
+## Validation Checkpoints
+
+Before deploying queue-based workflows, verify:
+
+1. **Connection check** - Confirm Redis is reachable and `createSwarmQueue` returns without error
+2. **Job submission** - Submit a test job and verify it appears in `getMetrics().waiting`
+3. **Worker processing** - Start a worker and confirm the test job transitions to `completed`
+4. **Retry behavior** - Submit a failing job and verify retry attempts match `defaultJobOptions.attempts`
+5. **Graceful shutdown** - Send SIGTERM and confirm worker drains active jobs before stopping
 
 ## Performance Tuning
 

--- a/packages/opencode-swarm-plugin/global-skills/skill-creator/SKILL.md
+++ b/packages/opencode-swarm-plugin/global-skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
+description: "Creates and updates agent skills by writing YAML frontmatter, defining trigger conditions, structuring SKILL.md files, and organizing bundled resources. Use when creating a new skill, updating an existing skill, writing skill descriptions, scaffolding skill directories, planning skill contents, or extending agent capabilities with specialized knowledge, workflows, or tool integrations. Use when authoring skills, designing skill triggers, building skill templates, or validating skill format."
 license: Complete terms in LICENSE.txt
 ---
 

--- a/packages/opencode-swarm-plugin/global-skills/skill-generator/SKILL.md
+++ b/packages/opencode-swarm-plugin/global-skills/skill-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-generator
-description: Meta-skill for generating new skills with proper format and structure. Use when creating new skills for the swarm system or when agents need to generate skill scaffolds. Ensures skills follow conventions (frontmatter format, directory structure, bundled resources).
+description: "Generates new skill scaffolds by creating SKILL.md files, writing YAML frontmatter with name and description fields, and setting up directory structures with scripts/, references/, and assets/ folders. Use when generating a new skill, scaffolding skill directories, bootstrapping skill templates, or initializing skill files for the swarm system. Validates frontmatter format, checks naming conventions, and ensures skills follow established conventions."
 ---
 
 # Skill Generator
@@ -149,6 +149,20 @@ Checks:
 - No TODO placeholders
 - No extraneous files
 - Naming conventions
+
+## Error Recovery After Validation
+
+If validation fails, apply these fixes:
+
+| Error | Fix |
+|-------|-----|
+| Missing `name` field | Add `name:` to YAML frontmatter matching the directory name |
+| Missing `description` field | Write a description including what the skill does and when to use it |
+| TODO placeholders found | Replace all TODO text with actual content or remove the placeholder |
+| Extraneous files (README.md, etc.) | Delete non-essential files; keep only SKILL.md and bundled resources |
+| Name mismatch | Rename the `name:` field to match the skill directory name exactly |
+
+Re-run `bun scripts/validate-skill.ts path/to/skill` after each fix to confirm resolution.
 
 ## Reference
 

--- a/packages/opencode-swarm-plugin/global-skills/swarm-coordination/SKILL.md
+++ b/packages/opencode-swarm-plugin/global-skills/swarm-coordination/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swarm-coordination
-description: Multi-agent coordination patterns for OpenCode swarm workflows. Use when working on complex tasks that benefit from parallelization, when coordinating multiple agents, or when managing task decomposition. Do NOT use for simple single-agent tasks.
+description: "Orchestrates multi-agent swarm workflows by spawning worker agents, distributing subtasks, reserving files, and aggregating results. Use when decomposing complex tasks into parallel subtasks, coordinating multiple agents, managing task dependencies, or monitoring worker progress. Use when parallelizing work across agents, splitting a task into concurrent pieces, running a swarm, or orchestrating distributed coding work. Do NOT use for simple single-agent tasks. Covers Socratic planning, knowledge gathering, file ownership, review loops, and failure recovery."
 tags:
   - swarm
   - multi-agent

--- a/packages/opencode-swarm-plugin/global-skills/system-design/SKILL.md
+++ b/packages/opencode-swarm-plugin/global-skills/system-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: system-design
-description: Principles for building reusable coding systems. Use when designing modules, APIs, CLIs, or any code meant to be used by others. Based on "A Philosophy of Software Design" by John Ousterhout. Covers deep modules, complexity management, and design red flags.
+description: "Applies software design principles to evaluate and improve code architecture. Use when designing modules, APIs, CLIs, or interfaces meant to be used by others. Use when performing code review, evaluating interface design, refactoring for simplicity, reducing complexity, identifying design red flags, or deciding between deep and shallow module boundaries. Analyzes information hiding, error handling strategies, and abstraction depth. Based on 'A Philosophy of Software Design' by John Ousterhout."
 tags:
   - design
   - architecture


### PR DESCRIPTION
Hullo @joelhooks 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the ten most improved:

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/2ac41560-6200-4da3-ab0c-c6356643d766" />

Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| always-on-guidance (claude) | 44% | 88% | +44% |
| always-on-guidance (opencode) | 51% | 93% | +42% | 
| gh-issue-triage | 49% | 89% | +40% |
| pr-triage | 66% | 100% | +34% |
| tdd | 55% | 89% | +34% |
| ralph-supervisor | 60% | 89% | +29% |
| skill-creator (global) | 76% | 93% | +17% |
| swarm-coordination (claude) | 81% | 96% | +15% | 
| swarm-coordination (global) | 76% | 89% | +13% | 
| queue | 77% | 89% | +12% |
| skill-generator | 81% | 93% | +12% |
| swarm-coordination (opencode-claude) | 89% | 96% | +7% | 
| cli-builder | 83% | 90% | +7% |
| swarm-coordination (example) | 76% | 81% | +5% | 
| learning-systems | 76% | 81% | +5% |
| openclaw-messaging | 94% | 94% | 0% |
| swarm-cli | 88% | 88% | 0% |
| release | 100% | 100% | 0% |
| publish-package-cicd | 100% | 100% | 0% |
| testing-patterns | 100% | 100% | 0% |

Average score: 64% → 92% (+28%)

Description improvements (all 20 skills below 100%):
- Added explicit "Use when..." clauses with concrete trigger scenarios
- Expanded abbreviated/abstract descriptions into specific actions
- Added natural trigger terms users would actually say
- Converted all block scalar descriptions to standard quoted string format

Content improvements (targeted, where review flagged gaps):
- always-on-guidance (both): Defined insider terms "bd" and "cass" inline; added concrete reserve/edit/release workflow example
- ralph-supervisor: Added Quick Start section with executable tool invocation examples for all 6 core tools
- openclaw-messaging: Added message delivery verification pattern with --json output
- swarm-coordination (claude-code-swarm-plugin): Removed unnecessary "Tool Access (Wildcard)" section
- cli-builder: Replaced generic "When to Build a CLI" section with concrete 7-step CLI Build Workflow
- queue: Added validation checkpoints section with 5 concrete verification steps
- skill-generator: Added error recovery guidance table mapping common validation errors to fixes
- learning-systems: Added natural trigger tags for discoverability
- gh-issue-triage: Removed duplicated frontmatter block; clarified "file cells" terminology

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at this Tessl guide: https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices and ask it to optimize your skill. Ping me - @popey - if you hit any snags.

Thanks in advance 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Enhanced skill documentation across multiple packages with expanded, more detailed descriptions clarifying usage scenarios and trigger conditions
* Added new tags to improve skill organization and discoverability
* Introduced workflow examples and quick-start guides for key skills (ralph-supervisor, cli-builder)
* Added validation checkpoints and error recovery guidance sections
* Improved clarity on when and how to use coordination, messaging, and guidance features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->