### PR TITLE
fix: auto-inject start_time for swarm_complete

### DIFF
--- a/packages/claude-code-swarm-plugin/bin/mcp-server.ts
+++ b/packages/claude-code-swarm-plugin/bin/mcp-server.ts
@@ -389,11 +389,11 @@ const TOOL_DEFINITIONS: ToolInfo[] = [
         agent_name: { type: "string", description: "Agent name (required)" },
         bead_id: { type: "string", description: "Bead/cell ID (required)" },
         summary: { type: "string", description: "Work summary (required)" },
-        start_time: { type: "number", description: "Start timestamp (required)" },
+        start_time: { type: "number", description: "Start timestamp (auto-injected as Date.now() if not provided)" },
         files_touched: { type: "array", items: { type: "string" }, description: "Files that were modified" },
         skip_verification: { type: "boolean", description: "Skip verification gate" },
       },
-      required: ["project_key", "agent_name", "bead_id", "summary", "start_time"],
+      required: ["project_key", "agent_name", "bead_id", "summary"],
     },
   },
 
@@ -620,6 +620,10 @@ function coerceArrayParams(name: string, args: Record<string, unknown>): Record<
  */
 function executeTool(name: string, args: Record<string, unknown>): string {
   try {
+    // Auto-inject start_time for swarm_complete if not provided
+    if (name === "swarm_complete" && args.start_time === undefined) {
+      args = { ...args, start_time: Date.now() };
+    }
     const coercedArgs = coerceArrayParams(name, args);
     const argsJson = JSON.stringify(coercedArgs);
     const output = execFileSync("swarm", ["tool", name, "--json", argsJson], {

--- a/packages/opencode-swarm-plugin/src/swarm-orchestrate.test.ts
+++ b/packages/opencode-swarm-plugin/src/swarm-orchestrate.test.ts
@@ -834,8 +834,6 @@ describe("anti-pattern auto-deprecation integration", () => {
 describe("eval_records duration tracking", () => {
   test("duration should be calculated correctly from start_time", () => {
     // This is a unit test for the duration calculation logic
-    // After fix: start_time is REQUIRED, so we always calculate duration
-    
     const startTime = Date.now() - 5000; // 5 seconds ago
     const completionDurationMs = Date.now() - startTime;
     
@@ -844,22 +842,15 @@ describe("eval_records duration tracking", () => {
     expect(completionDurationMs).toBeLessThan(5500);
   });
   
-  test("swarm_complete requires start_time parameter", () => {
-    // After fix: start_time is no longer optional
+  test("swarm_complete accepts start_time as optional (auto-defaults to Date.now())", () => {
     const { args } = swarm_complete;
     
     // Verify start_time is in the schema
     expect(args).toHaveProperty("start_time");
     
-    // Try to parse undefined - should fail since it's required now
-    try {
-      args.start_time.parse(undefined);
-      // If we get here, start_time is optional (which would be wrong)
-      expect(true).toBe(false); // Force fail
-    } catch (error) {
-      // Good - start_time is required
-      expect(error).toBeDefined();
-    }
+    // start_time is now optional — should parse undefined without error
+    const result = args.start_time.safeParse(undefined);
+    expect(result.success).toBe(true);
   });
   
   test("swarm_record_outcome schema requires duration_ms", () => {

--- a/packages/opencode-swarm-plugin/src/swarm-orchestrate.ts
+++ b/packages/opencode-swarm-plugin/src/swarm-orchestrate.ts
@@ -974,7 +974,7 @@ export const swarm_broadcast = tool({
  */
 export const swarm_complete = tool({
   description:
-    "Mark subtask complete with Verification Gate. REQUIRED: project_key, agent_name, bead_id (from your task assignment), summary, start_time (Date.now() from when you started). Before calling: 1) hivemind_store your learnings, 2) list files_touched for verification. Runs typecheck/tests before finalizing.",
+    "Mark subtask complete with Verification Gate. REQUIRED: project_key, agent_name, bead_id (from your task assignment), summary. OPTIONAL: start_time (auto-defaults to Date.now()). Before calling: 1) hivemind_store your learnings, 2) list files_touched for verification. Runs typecheck/tests before finalizing.",
   args: {
     project_key: tool.schema.string().describe("Project path (e.g., '/Users/name/project')"),
     agent_name: tool.schema.string().describe("Your agent name from swarmmail_init"),
@@ -1000,7 +1000,8 @@ export const swarm_complete = tool({
       .describe("Files that were originally planned to be modified"),
     start_time: tool.schema
       .number()
-      .describe("Task start timestamp (Unix ms) for duration calculation - REQUIRED for accurate analytics"),
+      .optional()
+      .describe("Task start timestamp (Unix ms) for duration calculation. Auto-defaults to Date.now() if not provided."),
     error_count: tool.schema
       .number()
       .optional()
@@ -1035,19 +1036,22 @@ export const swarm_complete = tool({
     if (!args.project_key) missing.push("project_key");
     if (!args.agent_name) missing.push("agent_name");
     if (!args.summary) missing.push("summary");
-    if (args.start_time === undefined) missing.push("start_time");
+    // Auto-inject start_time if not provided — LLM agents can't provide
+    // meaningful start times, and it's only used for duration analytics.
+    if (args.start_time === undefined) {
+      args.start_time = Date.now();
+    }
 
     if (missing.length > 0) {
       return JSON.stringify({
         success: false,
         error: `Missing required parameters: ${missing.join(", ")}`,
-        hint: "swarm_complete marks a subtask as done. All parameters are required.",
+        hint: "swarm_complete marks a subtask as done. project_key, agent_name, bead_id, and summary are required. start_time auto-defaults to Date.now().",
         example: {
           project_key: "/path/to/project",
           agent_name: "your-agent-name",
           bead_id: "epic-id.subtask-num OR cell-id from hive",
           summary: "Brief description of what you completed",
-          start_time: Date.now(),
           files_touched: ["src/file1.ts", "src/file2.ts"],
         },
         tip: "The bead_id comes from swarm_spawn_subtask or hive_create. Check your task assignment for the correct ID.",

--- a/packages/swarm-tools/index.ts
+++ b/packages/swarm-tools/index.ts
@@ -12,6 +12,10 @@ import { execFileSync } from "child_process";
 
 function executeSwarmTool(name: string, args: Record<string, unknown>): string {
   try {
+    // Auto-inject start_time for swarm_complete if not provided
+    if (name === "swarm_complete" && args.start_time === undefined) {
+      args = { ...args, start_time: Date.now() };
+    }
     const argsJson = JSON.stringify(args);
     const output = execFileSync("swarm", ["tool", name, "--json", argsJson], {
       encoding: "utf-8",
@@ -361,11 +365,11 @@ export const SWARM_TOOLS = [
         agent_name: { type: "string", description: "Agent name (required)" },
         bead_id: { type: "string", description: "Bead/cell ID (required)" },
         summary: { type: "string", description: "Work summary (required)" },
-        start_time: { type: "number", description: "Start timestamp (required)" },
+        start_time: { type: "number", description: "Start timestamp (auto-injected as Date.now() if not provided)" },
         files_touched: { type: "string", description: "Files touched (JSON array)" },
         skip_verification: { type: "boolean", description: "Skip verification gate" },
       },
-      required: ["project_key", "agent_name", "bead_id", "summary", "start_time"],
+      required: ["project_key", "agent_name", "bead_id", "summary"],
       additionalProperties: false,
     },
   },


### PR DESCRIPTION
## Summary
- Auto-inject `start_time` when not provided by LLM agents, fixing "Missing required parameters: start_time" error

## Problem
`swarm_complete` fails with `Error: Missing required parameters: start_time` because:
- The CLI validates `start_time` as required
- Plugin wrappers don't include it in the args passed to the CLI
- LLM agents can't provide meaningful start times anyway — it's only used for duration analytics

## Fix
- Removed `start_time` from required parameters across all 3 plugin wrappers
- Auto-inject `Date.now()` as default when `start_time` is not provided
- Updated tests to validate optional behavior

### Files changed
| File | Change |
|------|--------|
| `packages/swarm-tools/index.ts` | Removed from required, auto-inject default |
| `packages/claude-code-swarm-plugin/bin/mcp-server.ts` | Same |
| `packages/opencode-swarm-plugin/src/swarm-orchestrate.ts` | Schema `.optional()`, auto-default |
| `packages/opencode-swarm-plugin/src/swarm-orchestrate.test.ts` | Updated test |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `swarm_complete` tool now auto-injects the current timestamp when `start_time` is omitted, simplifying tool invocation.

* **Tests**
  * Updated test suite to validate optional `start_time` parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->