### PR TITLE
fix: correct Drizzle schema status default quoting

### DIFF
--- a/packages/swarm-mail/src/db/schema/memory.ts
+++ b/packages/swarm-mail/src/db/schema/memory.ts
@@ -64,9 +64,9 @@ const vector = (dimension: number) =>
 export const memories = sqliteTable("memories", {
   id: text("id").primaryKey(),
   content: text("content").notNull(),
-  metadata: text("metadata").default("'{}'"),
-  collection: text("collection").default("'default'"),
-  tags: text("tags").default("'[]'"),
+  metadata: text("metadata").default("{}"),
+  collection: text("collection").default("default"),
+  tags: text("tags").default("[]"),
   created_at: text("created_at").default("(datetime('now'))"),
   updated_at: text("updated_at").default("(datetime('now'))"),
   decay_factor: real("decay_factor").default(1.0),
@@ -83,7 +83,7 @@ export const memories = sqliteTable("memories", {
   last_accessed: text("last_accessed").default("(datetime('now'))"),
   // Fact categorization
   category: text("category"), // relationship, milestone, status, preference, context
-  status: text("status").default("'active'"), // active, superseded
+  status: text("status").default("active"), // active, superseded
 });
 
 /**
@@ -140,7 +140,7 @@ export const entities = sqliteTable("entities", {
   entity_type: text("entity_type").notNull(),
   canonical_name: text("canonical_name"),
   pref_label: text("pref_label"),
-  alt_labels: text("alt_labels").default("'[]'"),
+  alt_labels: text("alt_labels").default("[]"),
   created_at: text("created_at").default("(datetime('now'))"),
   updated_at: text("updated_at").default("(datetime('now'))"),
 }, (table) => [

--- a/packages/swarm-mail/src/memory/migrations.ts
+++ b/packages/swarm-mail/src/memory/migrations.ts
@@ -350,6 +350,44 @@ export const memorySelfHealColumnsLibSQL: Migration = {
 };
 
 /**
+ * Migration v13 (libSQL): Fix corrupted default values from Drizzle quoting bug
+ *
+ * Bug: Drizzle schema used .default("'active'") instead of .default("active").
+ * Drizzle wraps the value in quotes automatically, so the extra quotes became
+ * part of the stored string: 'active' (with literal quote chars) instead of active.
+ *
+ * This affected: status, metadata, collection, tags, alt_labels columns.
+ * Impact: WHERE status = 'active' never matched rows containing literal quote chars.
+ *
+ * This migration strips the spurious quotes from existing rows.
+ */
+export const fixQuotedDefaultsLibSQL: Migration = {
+  version: 13,
+  description: "Fix corrupted default values from Drizzle .default() quoting bug",
+  up: `
+    -- Fix status column: 'active' (with quotes) → active
+    UPDATE memories SET status = 'active' WHERE status = '''active''';
+    UPDATE memories SET status = 'superseded' WHERE status = '''superseded''';
+
+    -- Fix metadata column: '{}' (with quotes) → {}
+    UPDATE memories SET metadata = '{}' WHERE metadata = '''{}''';
+
+    -- Fix collection column: 'default' (with quotes) → default
+    UPDATE memories SET collection = 'default' WHERE collection = '''default''';
+
+    -- Fix tags column: '[]' (with quotes) → []
+    UPDATE memories SET tags = '[]' WHERE tags = '''[]''';
+
+    -- Fix alt_labels on entities table
+    UPDATE entities SET alt_labels = '[]' WHERE alt_labels = '''[]''';
+  `,
+  down: `
+    -- Cannot reliably reverse: we don't know which rows had the original bug vs were inserted correctly
+    SELECT 1;
+  `,
+};
+
+/**
  * Export memory migrations array
  */
 export const memoryMigrations: Migration[] = [memoryMigration];
@@ -358,6 +396,7 @@ export const memoryMigrationsLibSQL: Migration[] = [
   memorySchemaOverhaulLibSQL,
   sessionMetadataExtensionLibSQL,
   memorySelfHealColumnsLibSQL,
+  fixQuotedDefaultsLibSQL,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Fix Drizzle ORM `.default()` quoting bug in memory schema that caused `hivemind_find` to return 0 results

## Problem
The Drizzle schema used `.default("'active'")` which stores literal quote characters in the `status` column (value: `'active'` = 8 chars with embedded quotes). The search WHERE clause filters for `status = 'active'` (6 chars, no quotes), so **all rows were excluded** from search results.

This affected 5 columns in the memory schema: `status`, `metadata`, `collection`, `tags`, and `alt_labels`.

## Fix
1. **Schema**: Changed all `.default("'value'")` to `.default("value")` in `packages/swarm-mail/src/db/schema/memory.ts` (5 occurrences)
2. **Migration**: Added v13 migration to repair existing corrupted rows with embedded quotes

## Impact
- `hivemind_find()` was returning 0 results despite 72+ memories with valid embeddings
- After fix, semantic search works correctly with similarity scores 0.6-0.75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database default values for memory and entity fields to use proper formatting.
  * Added automatic data migration to fix existing records with improperly formatted values, ensuring consistency across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->