### PR TITLE
ci: add npm provenance to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -21,7 +22,9 @@ jobs:
       - uses: oven-sh/setup-bun@v2
 
       - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+        run: printf '%s' "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -137,6 +140,9 @@ jobs:
           publish: bun run ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Get release info
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary
- grants OIDC `id-token: write` to the release workflow
- enables npm provenance for Changesets/Bun publish via `NPM_CONFIG_PROVENANCE=true`
- writes `.npmrc` with `printf` from an env var

## Verification
- parsed all workflow YAML locally with Ruby `YAML.load_file`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration with explicit permissions for managing pull requests and repository content throughout the entire release process.
  * Refined npm authentication and token handling setup with enhanced security configurations applied to package publishing operations.
  * Enabled package provenance verification functionality for all published releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joelhooks/swarm-tools/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->