### PR TITLE
fix(swarm-mail): FTS5 MATCH incompatible with Drizzle sql template parameterization

### DIFF
--- a/packages/swarm-mail/src/memory/store.ts
+++ b/packages/swarm-mail/src/memory/store.ts
@@ -333,9 +333,9 @@ export function createMemoryStore(db: SwarmDb) {
       }
 
       // FTS5 requires raw SQL - not yet in Drizzle's type-safe API
-      // Quote search query to escape FTS5 operators (hyphens, etc.)
-      // Without quotes, "unique-keyword-12345" → "unique" MINUS "keyword" → error
-      const quotedQuery = `"${searchQuery.replace(/"/g, '""')}"`;
+      // Use sql.raw() for the MATCH value since FTS5 does not support bound parameters
+      // Single-quote the value for SQL string literal (not double-quote which is an identifier)
+      const escapedQuery = searchQuery.replace(/'/g, "''");
 
       // Build filters
       const collectionFilter = collection ? sql`AND m.collection = ${collection}` : sql``;
@@ -365,7 +365,7 @@ export function createMemoryStore(db: SwarmDb) {
           fts.rank as score
         FROM memories_fts fts
         JOIN memories m ON m.rowid = fts.rowid
-        WHERE fts.content MATCH ${quotedQuery}
+        WHERE fts.content MATCH ${sql.raw("'" + escapedQuery + "'")}
           ${collectionFilter}
           ${decayFilter}
           ${statusFilter}


### PR DESCRIPTION
## Problem

`hivemind_find` always returns `{ results: [], count: 0 }` for FTS searches. Two bugs in `store.ts`:

### Bug 1: FTS5 MATCH uses double-quoted identifiers instead of string literals

`packages/swarm-mail/src/memory/store.ts:336`:
```ts
const quotedQuery = `"${searchQuery.replace(/"/g, '""')}"`;
```

In SQLite, `MATCH "hivemind"` treats `"hivemind"` as a column reference (identifier), not a string literal. Should be `MATCH 'hivemind'` (single-quoted string literal).

### Bug 2: Drizzle `sql` template parameterization incompatible with FTS5 MATCH

`packages/swarm-mail/src/memory/store.ts:368`:
```ts
const results = await db.all<...>(sql`
  ...
  WHERE fts.content MATCH ${quotedQuery}
  ...
`);
```

Drizzle's `sql` template tag parameterizes interpolated values as `?` placeholders. FTS5's MATCH operator **does not support bound parameters** -- the expression must be a literal string in the SQL text. The query silently returns 0 rows.

## Changes

### `packages/swarm-mail/src/memory/store.ts` -- Fix FTS5 MATCH quoting + parameterization

Two changes:

1. Fix MATCH quoting (double-quote to single-quote)
2. Use `sql.raw()` to inline the value directly into SQL text, bypassing Drizzle's `?` parameterization

```diff
- const quotedQuery = `"${searchQuery.replace(/"/g, '""')}"`;
+ const escapedQuery = searchQuery.replace(/'/g, "''");
- WHERE fts.content MATCH ${quotedQuery}
+ WHERE fts.content MATCH ${sql.raw("'" + escapedQuery + "'")}
```

## Testing

- [x] FTS search returns results after fix (confirmed against local DB)
- [x] Vector search continues to work (unchanged)
- [x] SQL injection prevented (single quotes escaped)
- [x] No regressions in existing tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Full Text Search (FTS) query handling to properly process special characters in search queries, particularly single quotes, ensuring more reliable search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->