### PR TITLE
fix(swarm-mail): stop status default corrupting new memories

### DIFF
--- a/.changeset/fix-memory-status-default-quotes.md
+++ b/.changeset/fix-memory-status-default-quotes.md
@@ -1,0 +1,28 @@
+---
+"opencode-swarm-plugin": patch
+"swarm-mail": patch
+---
+
+## 🐝 Memories Were Whispering Into a Room With No Door
+
+> "Program testing can be used to show the presence of bugs, but never to show their absence." — Edsger W. Dijkstra
+
+**What changed:**
+- `packages/swarm-mail/src/db/schema/memory.ts`: the Drizzle column default for `status` carried literal quote characters — `.default("'active'")` instead of `.default("active")`. `store()` never sets `status` explicitly, so every memory was written with the 8-character string `'active'` (quotes included, as data) instead of the correct 6-character `active`.
+- `search()` and `ftsSearch()` filter on `status = 'active'`, so every corrupted row silently became permanently unsearchable — while `getStats()` kept counting the rows and reporting a perfectly healthy corpus. Store succeeds, search returns nothing, stats lies. Indistinguishable from an empty index.
+- Added a regression test that reads the *raw* `status` column value straight off `store()`'s output, not just round-trip search behavior — the existing widened `statusFilter` (`m.status = 'active' OR m.status = '''active'''`) already masks this bug on the read side, so only a direct column read catches the write-side corruption.
+
+**Why it matters:**
+
+Found in the wild: this silently disabled semantic memory across a full multi-agent session. Every agent's "no prior results" looked exactly like a legitimately empty index — no error, no warning, nothing to notice, right up until someone checked the raw column against the stats count by hand.
+
+**Migration:** none needed. The existing `statusFilter` widening (already on `main`, unchanged by this patch) keeps pre-existing corrupted rows searchable — this fix only stops *new* writes from being corrupted going forward. The widening can be dropped in a future major version once old installs have aged out.
+
+**Backward compatible:** yes — no data is lost or requires backfill; previously-corrupted rows stay reachable through the existing filter, they just stop multiplying.
+
+```
+    ,-.__,-.
+   ( o     o )   "getStats() says I'm fine."
+    \   ^   /    "search() says I don't exist."
+     `-----'     turns out: I was written with my own name in quotes.
+```

--- a/packages/swarm-mail/src/db/schema/memory.ts
+++ b/packages/swarm-mail/src/db/schema/memory.ts
@@ -83,7 +83,7 @@ export const memories = sqliteTable("memories", {
   last_accessed: text("last_accessed").default("(datetime('now'))"),
   // Fact categorization
   category: text("category"), // relationship, milestone, status, preference, context
-  status: text("status").default("'active'"), // active, superseded
+  status: text("status").default("active"), // active, superseded
 });
 
 /**

--- a/packages/swarm-mail/src/memory/store.drizzle.integration.test.ts
+++ b/packages/swarm-mail/src/memory/store.drizzle.integration.test.ts
@@ -6,9 +6,22 @@
  */
 
 import { createClient } from "@libsql/client";
-import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 import { sql } from "drizzle-orm";
+import type { SwarmDb } from "../db/client.js";
 import { createDrizzleClient } from "../db/drizzle.js";
+import {
+  createInMemorySwarmMailLibSQL,
+  toSwarmDb,
+} from "../libsql.convenience.js";
+import type { SwarmMailAdapter } from "../types/adapter.js";
 import { type Memory, createMemoryStore } from "./store.js";
 
 /**
@@ -372,41 +385,21 @@ describe("Memory Store (Drizzle) - Status Corruption Regression", () => {
   // so every memory became permanently unsearchable while getStats() still
   // reported a healthy count. Store succeeded, search returned empty: silent
   // write-only corruption with stats showing everything was fine.
-  let db: ReturnType<typeof createDrizzleClient>;
+  let swarmMail: SwarmMailAdapter;
+  let db: SwarmDb;
   let store: ReturnType<typeof createMemoryStore>;
 
-  beforeEach(async () => {
-    const client = createClient({ url: ":memory:" });
-
-    await client.execute(`
-      CREATE TABLE memories (
-        id TEXT PRIMARY KEY,
-        content TEXT NOT NULL,
-        metadata TEXT DEFAULT '{}',
-        collection TEXT DEFAULT 'default',
-        tags TEXT DEFAULT '[]',
-        created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now')),
-        decay_factor REAL DEFAULT 1.0,
-        embedding F32_BLOB(1024),
-        valid_from TEXT,
-        valid_until TEXT,
-        superseded_by TEXT REFERENCES memories(id),
-        auto_tags TEXT,
-        keywords TEXT,
-        access_count TEXT DEFAULT '0',
-        last_accessed TEXT DEFAULT (datetime('now')),
-        category TEXT,
-        status TEXT DEFAULT 'active'
-      )
-    `);
-    await client.execute(`
-      CREATE INDEX idx_memories_embedding
-      ON memories(libsql_vector_idx(embedding))
-    `);
-
-    db = createDrizzleClient(client);
+  beforeAll(async () => {
+    swarmMail = await createInMemorySwarmMailLibSQL(
+      "status-corruption-regression",
+    );
+    const dbAdapter = await swarmMail.getDatabase();
+    db = toSwarmDb(dbAdapter);
     store = createMemoryStore(db);
+  });
+
+  afterAll(async () => {
+    await swarmMail.close();
   });
 
   test("store() writes a clean 'active' status, not a quoted literal", async () => {
@@ -453,13 +446,6 @@ describe("Memory Store (Drizzle) - Status Corruption Regression", () => {
 
     await store.store(memory, mockEmbedding(8));
 
-    await db.run(sql`
-      CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(content, content='memories', content_rowid='rowid')
-    `);
-    await db.run(
-      sql`INSERT INTO memories_fts(rowid, content) SELECT rowid, content FROM memories`,
-    );
-
     const results = await store.ftsSearch("unique-fts-marker-zzyzx");
     expect(results.map((r) => r.memory.id)).toContain("mem-status-3");
   });
@@ -483,5 +469,27 @@ describe("Memory Store (Drizzle) - Status Corruption Regression", () => {
 
     const results = await store.search(mockEmbedding(3), { threshold: 0 });
     expect(results.map((r) => r.memory.id)).toContain("mem-legacy");
+  });
+
+  test("ftsSearch() still finds legacy-corrupted rows (status = literal 'active')", async () => {
+    // Mirrors the search() legacy-status test above: ftsSearch() has its own
+    // end-to-end query path and status filter, so it needs its own coverage
+    // of the corrupted-status case rather than inheriting search()'s.
+    const memory: Memory = {
+      id: "mem-legacy-fts",
+      content: "unique-fts-marker-legacy durable fixes",
+      metadata: {},
+      collection: "default",
+      createdAt: new Date(),
+    };
+    await store.store(memory, mockEmbedding(9));
+
+    // Force the legacy-corrupted value directly, bypassing the (now-fixed) default.
+    await db.run(
+      sql`UPDATE memories SET status = '''active''' WHERE id = ${memory.id}`,
+    );
+
+    const results = await store.ftsSearch("unique-fts-marker-legacy");
+    expect(results.map((r) => r.memory.id)).toContain("mem-legacy-fts");
   });
 });

--- a/packages/swarm-mail/src/memory/store.drizzle.test.ts
+++ b/packages/swarm-mail/src/memory/store.drizzle.test.ts
@@ -7,6 +7,7 @@
 
 import { createClient } from "@libsql/client";
 import { beforeEach, describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
 import { createDrizzleClient } from "../db/drizzle.js";
 import { type Memory, createMemoryStore } from "./store.js";
 
@@ -297,7 +298,7 @@ describe("Memory Store (Drizzle) - Vector Search", () => {
           collection: mem.collection,
           createdAt: new Date(),
         },
-        mem.embedding
+        mem.embedding,
       );
     }
   });
@@ -357,5 +358,130 @@ describe("Memory Store (Drizzle) - Vector Search", () => {
 
     const results = await store.search(mockEmbedding(1));
     expect(results).toEqual([]);
+  });
+});
+
+describe("Memory Store (Drizzle) - Status Corruption Regression", () => {
+  // Regression test for a bug where the Drizzle schema's column default
+  // (db/schema/memory.ts `status: text("status").default("'active'")`) contained
+  // literal quote characters. Drizzle's SQLite dialect binds `.default()` as a
+  // client-side insert parameter whenever a column is omitted from `.values()`,
+  // so every memory silently got a `status` of the 8-char string `'active'`
+  // instead of `active` - independent of what the table's raw SQL DDL default said.
+  // search()/ftsSearch() filtered on `status = 'active'`, which never matched,
+  // so every memory became permanently unsearchable while getStats() still
+  // reported a healthy count. Store succeeded, search returned empty: silent
+  // write-only corruption with stats showing everything was fine.
+  let db: ReturnType<typeof createDrizzleClient>;
+  let store: ReturnType<typeof createMemoryStore>;
+
+  beforeEach(async () => {
+    const client = createClient({ url: ":memory:" });
+
+    await client.execute(`
+      CREATE TABLE memories (
+        id TEXT PRIMARY KEY,
+        content TEXT NOT NULL,
+        metadata TEXT DEFAULT '{}',
+        collection TEXT DEFAULT 'default',
+        tags TEXT DEFAULT '[]',
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now')),
+        decay_factor REAL DEFAULT 1.0,
+        embedding F32_BLOB(1024),
+        valid_from TEXT,
+        valid_until TEXT,
+        superseded_by TEXT REFERENCES memories(id),
+        auto_tags TEXT,
+        keywords TEXT,
+        access_count TEXT DEFAULT '0',
+        last_accessed TEXT DEFAULT (datetime('now')),
+        category TEXT,
+        status TEXT DEFAULT 'active'
+      )
+    `);
+    await client.execute(`
+      CREATE INDEX idx_memories_embedding
+      ON memories(libsql_vector_idx(embedding))
+    `);
+
+    db = createDrizzleClient(client);
+    store = createMemoryStore(db);
+  });
+
+  test("store() writes a clean 'active' status, not a quoted literal", async () => {
+    const memory: Memory = {
+      id: "mem-status-1",
+      content: "Some content",
+      metadata: {},
+      collection: "default",
+      createdAt: new Date(),
+    };
+
+    await store.store(memory, mockEmbedding(1));
+
+    const rows = await db.all<{ status: string }>(
+      sql`SELECT status FROM memories WHERE id = ${memory.id}`,
+    );
+    expect(rows[0]?.status).toBe("active");
+  });
+
+  test("a freshly stored memory is retrievable via search() (end-to-end)", async () => {
+    const memory: Memory = {
+      id: "mem-status-2",
+      content: "Findable content about durable fixes",
+      metadata: {},
+      collection: "default",
+      createdAt: new Date(),
+    };
+    const embedding = mockEmbedding(7);
+
+    await store.store(memory, embedding);
+
+    const results = await store.search(embedding, { threshold: 0 });
+    expect(results.map((r) => r.memory.id)).toContain("mem-status-2");
+  });
+
+  test("a freshly stored memory is retrievable via ftsSearch() (end-to-end)", async () => {
+    const memory: Memory = {
+      id: "mem-status-3",
+      content: "unique-fts-marker-zzyzx durable fixes",
+      metadata: {},
+      collection: "default",
+      createdAt: new Date(),
+    };
+
+    await store.store(memory, mockEmbedding(8));
+
+    await db.run(sql`
+      CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(content, content='memories', content_rowid='rowid')
+    `);
+    await db.run(
+      sql`INSERT INTO memories_fts(rowid, content) SELECT rowid, content FROM memories`,
+    );
+
+    const results = await store.ftsSearch("unique-fts-marker-zzyzx");
+    expect(results.map((r) => r.memory.id)).toContain("mem-status-3");
+  });
+
+  test("search() still finds legacy-corrupted rows (status = literal 'active')", async () => {
+    // Simulates a row written by an unpatched install before this fix, so
+    // memories already in production databases remain searchable.
+    const memory: Memory = {
+      id: "mem-legacy",
+      content: "Legacy corrupted row",
+      metadata: {},
+      collection: "default",
+      createdAt: new Date(),
+    };
+    await store.store(memory, mockEmbedding(3));
+
+    // Force the legacy-corrupted value directly, bypassing the (now-fixed) default.
+    await db.run(
+      sql`UPDATE memories SET status = '''active''' WHERE id = ${memory.id}`,
+    );
+
+    const results = await store.search(mockEmbedding(3), { threshold: 0 });
+    expect(results.map((r) => r.memory.id)).toContain("mem-legacy");
   });
 });


### PR DESCRIPTION
## Summary

Fixes a silent data-corruption bug in `swarm-mail`'s memory store: every stored memory got `status = "'active'"` (8 chars, literal embedded quotes) instead of `status = "active"` (6 chars). `search()` and `ftsSearch()` filter on `status = 'active'`, so every write silently became permanently unsearchable while `getStats()` kept reporting a healthy corpus. Store succeeds, search returns empty, stats lies — indistinguishable from a legitimately empty index.

**Found in the wild**: this silently disabled semantic memory across a full multi-agent session. Every agent's "no prior results" query looked exactly like a correctly-empty index — there was no error, no warning, nothing to notice. Only caught by manually inspecting the raw `status` column against `getStats()`'s reported count.

## Related issue

Addresses #176 (**not** using a closing keyword — see why below).

#176 documents the same root-cause class of bug — `.default()` receiving a SQL-literal string instead of a JS value — across **eight** `.default()` calls in `memory.ts`. This PR fixes exactly **one** of them: `status` (line 86 in the issue, the one causing the reported symptom of `hivemind_find` returning 0 results). The other six the issue's own table lists as broken — `metadata`, `collection`, `tags`, `created_at`, `updated_at`, `last_accessed` — are **not touched by this PR** and are still broken on this branch as of this commit (`access_count` was already fine per the issue). Merging this with a `Fixes #176` keyword would auto-close an issue that isn't fully resolved.

I deliberately didn't fold the other six into this PR — this fix is narrowly scoped, tested, and has a fails-without/passes-with demonstration for exactly the `status` bug. Widening it would mix an easy, well-understood, already-verified fix with five more schema changes (including two that need `sql` template literals for the `datetime('now')` defaults, a different fix shape) that haven't been through the same rigor. Suggest either: keep #176 open and re-scope its title/checklist to the remaining six, or I'm happy to open a narrowly-scoped follow-up PR for them once this one lands — your call.

## Bug flow

```
 WRITE PATH                                    READ PATH
 ══════════                                    ═════════

 store(memory)                                 search(query) / ftsSearch(query)
      │                                              │
      ▼                                              ▼
 status omitted from .values()                WHERE (m.status IS NULL
      │                                              OR m.status = 'active')
      ▼                                              │
 Drizzle client-side default kicks in                │
 (memory.ts schema):                                 │
   .default("'active'")                              │
      │                                              │
      ▼                                              │
 INSERT binds status = "'active'"                    │
 (8 chars, quotes included as data) ──────────X───────┘
      │                                     never matches
      ▼                                   ("'active'" != "active")
 Row committed successfully                          │
      │                                              ▼
      ▼                                       0 results returned
 getStats() counts the row:                          │
 "13/13 memories, healthy" ◄──────────────────────────┘
      │                                    (stats and search disagree —
      ▼                                     stats has no idea search is
 Silent, total, invisible corruption        filtering everything out)
```

## Root cause

`packages/swarm-mail/src/db/schema/memory.ts`:

```ts
status: text("status").default("'active'"), // BUG: literal quote chars
```

This looks like a copy-paste artifact from a raw-SQL default string, and it's easy to miss on review because **the table's raw `CREATE TABLE` DDL (`libsql-schema.ts`) already has the correct `DEFAULT 'active'`**. Reading just the DDL, everything looks fine.

But Drizzle's SQLite dialect doesn't route through the DDL default at all when a column is omitted from `.values()`. It binds `.default()` as a **client-side insert parameter** instead — confirmed in `node_modules/drizzle-orm/sqlite-core/dialect.js`:

```js
defaultValue = is(col.default, SQL) ? col.default : sql.param(col.default, col);
```

Whatever string the JS-level `.default()` was given gets bound literally as the parameter value. The correct raw-SQL DDL default is never consulted for this path — it's dead code as far as Drizzle-issued inserts are concerned. `store()` never sets `status` explicitly, so every `INSERT` bound the 8-character string `'active'` (with the quote characters as literal data) instead of the 6-character `active`.

**Why this survives casual review**: the DDL is correct, the column name is correct, the intent (`// active, superseded`) is stated right there in the comment — the only thing wrong is two stray characters buried in a `.default()` call, and the failure mode (silent, 100% reproducible, but invisible in stats) gives no signal to go looking for it.

### Why a `swarm-mail`-only fix doesn't reach the shipped binary

`opencode-swarm-plugin`'s build (`packages/opencode-swarm-plugin/scripts/build.ts`) has three targets:

- **Library** (`dist/index.js`, `dist/plugin.js`) — `swarm-mail` is external, resolved from `node_modules` at runtime.
- **CLI** (`dist/bin/swarm.js` — what the `hivemind_*` MCP tools actually shell out to) — `swarm-mail` is explicitly **not** external. Build script's own comment: *"swarm-mail is bundled into CLI to avoid version mismatch issues with global install."*
- **Marketplace bundle** (`dist/marketplace/index.js`) — same story, bundled because that distribution ships with no `node_modules`.

So the CLI binary is a frozen snapshot of `swarm-mail` source at last build time. Patching only the standalone `swarm-mail` package (e.g. a local `bun add swarm-tools@patched`) changes nothing the CLI executes — the fix has to land in `swarm-mail` source and get rebuilt through `opencode-swarm-plugin` for `dist/bin/swarm.js` / `dist/marketplace/index.js` to pick it up. Verified directly against a from-source rebuild: `grep -c 'default("active")'` against `dist/bin/swarm.js` and `dist/marketplace/index.js` shows the fix present in both after rebuild, `dist/index.js` / `dist/plugin.js` show 0 (expected — external there).

**This is also why the changeset (below) bumps both packages**, not just `swarm-mail` — a `swarm-mail`-only version bump wouldn't trigger `changesets/action` to republish `opencode-swarm-plugin`, so the CLI/marketplace tarballs on npm would stay frozen at the pre-fix source forever.

## The fix

**(a) Schema default** — the actual bug, one line:

```diff
-  status: text("status").default("'active'"), // active, superseded
+  status: text("status").default("active"), // active, superseded
```

**(b) Status filter widening** — already present in `main` (`search()` and `ftsSearch()` in `store.ts`, both already carry):

```ts
sql`AND (m.status IS NULL OR m.status = 'active' OR m.status = '''active''')`
```

This is a compat shim so memories already written by unpatched installs (with the corrupted `'active'` literal already sitting in their `status` column) stay searchable instead of being silently orphaned by (a). **This half was already correct on `main` and required no change** — this PR only needed (a). Both halves together: (a) stops new corruption, (b) keeps old corrupted rows reachable. **(b) can be dropped in a future major version** once corrupted rows have aged out / been backfilled, since it's pure legacy-compat surface.

## Test

Added to `store.drizzle.test.ts`, a new `describe("Memory Store (Drizzle) - Status Corruption Regression")` block. The key test asserts the **raw `status` column value** after `store()`, not just search behavior:

```ts
const rows = await db.all<{ status: string }>(
  sql`SELECT status FROM memories WHERE id = ${memory.id}`,
);
expect(rows[0]?.status).toBe("active");
```

This distinction matters: a naive `store()` → `find()`/`search()` round-trip test does **not** catch this bug, because the filter widening in (b) already masks it — a corrupted row is still findable through the widened `OR m.status = '''active'''` clause. The only way to catch the write-side bug is to inspect the column directly. That's exactly why it survived undetected — every "does search still work" sanity check passes even with the schema bug present.

Plus:
- End-to-end `store()` → `search()` round trip
- End-to-end `store()` → `ftsSearch()` round trip
- Regression guard: `search()` still finds a row with the legacy-corrupted status value (protects against (b) being narrowed again later)

### Demonstrated fails-without-fix / passes-with-fix

Reverted the schema line locally, reran:

```
$ bun test src/memory/store.drizzle.test.ts
error: expect(received).toBe(expected)
Expected: "active"
Received: "'active'"
(fail) Memory Store (Drizzle) - Status Corruption Regression > store() writes a clean 'active' status, not a quoted literal [0.66ms]
 17 pass
 1 fail
```

Restored the fix, reran:

```
$ bun test src/memory/store.drizzle.test.ts
 18 pass
 0 fail
 39 expect() calls
```

Maintainers can rerun this yourselves: revert the one-line diff in `memory.ts` above, run the targeted test, confirm the `Expected: "active", Received: "'active'"` failure, then restore it and confirm green.

## Verification

```
$ bun test src/memory/store.drizzle.test.ts     # targeted
 18 pass
 0 fail

$ bun test src/                                  # full swarm-mail suite
 1300 pass
 50 skip
 0 fail
 3318 expect() calls
Ran 1350 tests across 92 files.

$ bunx tsc --noEmit                              # clean, no output
```

One flaky, unrelated failure (`session-handoff.test.ts`, an ordering assertion — `Expected: 8, Received: 9`) appeared on the first full-suite run and was gone on rerun. Reproduced independently against **this branch's unmodified tip** by stashing this PR's changes and rerunning in isolation — same intermittent failure, confirming it's a pre-existing timing flake in that test's own setup, unrelated to this change. Flagging so it isn't mistaken for something this PR introduced.

## For the maintainer — release housekeeping

A few things that make this land cleanly with minimal back-and-forth:

**Changeset** — added `.changeset/fix-memory-status-default-quotes.md`, patch-level for both `opencode-swarm-plugin` and `swarm-mail`, following the "lore" convention documented in `AGENTS.md` (epigraph, before/after, ASCII art). Bumps both packages for the vendoring reason described above — matches the precedent set by `.changeset/fix-memory-database-path.md`, an earlier memory-layer fix that did the same for the same reason.

**Data migration** — not needed. The existing `statusFilter` widening in `search()`/`ftsSearch()` (unchanged by this PR, already on `main`) keeps rows with the corrupted `'active'` literal permanently searchable. Installs running the buggy version don't need any backfill; they just stop accumulating new corruption once this ships. A normalization migration to actually clean up the corrupted rows would be a nicer end state but is out of scope here — flagging it as a possible future cleanup, not blocking.

**Vouch** — already satisfied, no action needed on your end. `srmcguirt` is already in `.github/VOUCHED.td`, which is presumably why this PR wasn't auto-closed by `vouch-check-pr.yml`.

**CI status** — as of this update, `Vercel` shows `failure`, but that's an expected team-authorization gate on preview deploys for external contributors (unrelated to this change — it needs a team member to click "authorize" in the Vercel dashboard, not a code fix). `CodeRabbit` and both `Socket Security` checks pass. `CI` and `Eval Gate` haven't run at all yet — no workflow runs exist for this commit — because GitHub requires a maintainer to approve workflow runs for a first-time contributor. Whenever you get a moment: "Approve and run workflows" on this PR.

**Issue linking** — see the "Related issue" section above; used `Addresses #176` rather than a closing keyword since #176 documents more than this PR fixes.

---

### Test summary

| Suite | Result |
|---|---|
| Targeted regression tests | 18 pass / 0 fail |
| Full `swarm-mail` suite | 1300 pass / 50 skip / 0 fail |
| Typecheck (`tsc --noEmit`) | clean |
| Fails-without-fix demonstration | confirmed (`Expected: "active", Received: "'active'"`) |
| Changeset | added, patch × 2 packages (`swarm-mail`, `opencode-swarm-plugin`) |

### Credits

Bug found the hard way, in production, by a multi-agent swarm quietly losing all its memory for an entire session while reporting itself perfectly healthy. Root-caused down to the Drizzle dialect source. No AI agents were harmed in the making of this fix, though several were mildly confused about why nothing they remembered was coming back.

```
   ___
  /___\   status: "'active'"  ➜  status: "active"
 |     |
 | o o |   the extra quotes are gone now.
 |  ∪  |   ship it.
  \___/
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * New memories now receive the correct active status automatically.
  * Improved memory search reliability for both newly created memories and existing records.
  * Added support for finding memories through vector and full-text search, including legacy records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
